### PR TITLE
[BugFix#18] Crop overlay wasn't showing on FF

### DIFF
--- a/demo/bundle.js
+++ b/demo/bundle.js
@@ -20206,14 +20206,16 @@
 				_react2.default.createElement('div', { className: 'ReactCrop--drag-handle ord-w', 'data-ord': 'w' })
 			);
 		},
-		arrayDividedBy100: function arrayDividedBy100(arr, delimeter) {
-			delimeter = delimeter || ' ';
+		arrayDividedBy100: function arrayDividedBy100(arr) {
+			var delimeter = arguments.length <= 1 || arguments[1] === undefined ? ' ' : arguments[1];
+
 			return arr.map(function (number) {
 				return number / 100;
 			}).join(delimeter);
 		},
-		arrayToPercent: function arrayToPercent(arr, delimeter) {
-			delimeter = delimeter || ' ';
+		arrayToPercent: function arrayToPercent(arr) {
+			var delimeter = arguments.length <= 1 || arguments[1] === undefined ? ' ' : arguments[1];
+
 			return arr.map(function (number) {
 				return number + '%';
 			}).join(delimeter);
@@ -20247,15 +20249,13 @@
 				}
 			};
 		},
-		getImageClipStyle: function getImageClipStyle() {
-			var polygon = this.getPolygonValues();
+		getPolygonClipPath: function getPolygonClipPath() {
+			var _getPolygonValues = this.getPolygonValues();
 
-			var polygonVal = 'polygon(' + polygon.top.left + ', ' + polygon.top.right + ', ' + polygon.bottom.right + ', ' + polygon.bottom.left + ')';
+			var top = _getPolygonValues.top;
+			var bottom = _getPolygonValues.bottom;
 
-			return {
-				WebkitClipPath: polygonVal,
-				clipPath: 'url("#ReactCropperClipPolygon")'
-			};
+			return 'polygon(' + top.left + ', ' + top.right + ', ' + bottom.right + ', ' + bottom.left + ')';
 		},
 		onImageLoad: function onImageLoad(e) {
 			var crop = this.state.crop;
@@ -20289,11 +20289,17 @@
 				crop.height = crop.width / crop.aspect * imageAspect;
 			}
 		},
+
+
+		// We used dangerouslySetInnerHTML because react refuses to add the attribute 'clipPathUnits' to the rendered DOM
 		getClipPathHtml: function getClipPathHtml() {
-			var polygon = this.getPolygonValues(true);
-			// We used dangerouslySetInnerHTML because react refuses to add the attribute 'clipPathUnits' to the rendered DOM
+			var _getPolygonValues2 = this.getPolygonValues(true);
+
+			var top = _getPolygonValues2.top;
+			var bottom = _getPolygonValues2.bottom;
+
 			return {
-				__html: '<clipPath id="ReactCropperClipPolygon" clipPathUnits="objectBoundingBox">' + ('<polygon points="' + polygon.top.left + ', ' + polygon.top.right + ', ' + polygon.bottom.right + ', ' + polygon.bottom.left + '" />') + '</clipPath>'
+				__html: '<clipPath id="ReactCropperClipPolygon" clipPathUnits="objectBoundingBox">\n\t\t\t\t\t\t\t\t<polygon points="' + top.left + ', ' + top.right + ', ' + bottom.right + ', ' + bottom.left + '" />\n\t\t\t\t\t\t\t</clipPath>'
 			};
 		},
 		renderSvg: function renderSvg() {
@@ -20309,7 +20315,10 @@
 
 			if (!this.cropInvalid) {
 				cropSelection = this.createCropSelection();
-				imageClip = this.getImageClipStyle();
+				imageClip = {
+					WebkitClipPath: this.getPolygonClipPath(),
+					clipPath: 'url("#ReactCropperClipPolygon")'
+				};
 			}
 
 			var componentClasses = ['ReactCrop'];

--- a/demo/bundle.js
+++ b/demo/bundle.js
@@ -9366,6 +9366,7 @@
 	 */
 	var EventInterface = {
 	  type: null,
+	  target: null,
 	  // currentTarget is set when dispatching; no use in copying it here
 	  currentTarget: emptyFunction.thatReturnsNull,
 	  eventPhase: null,
@@ -9399,8 +9400,6 @@
 	  this.dispatchConfig = dispatchConfig;
 	  this.dispatchMarker = dispatchMarker;
 	  this.nativeEvent = nativeEvent;
-	  this.target = nativeEventTarget;
-	  this.currentTarget = nativeEventTarget;
 
 	  var Interface = this.constructor.Interface;
 	  for (var propName in Interface) {
@@ -9411,7 +9410,11 @@
 	    if (normalize) {
 	      this[propName] = normalize(nativeEvent);
 	    } else {
-	      this[propName] = nativeEvent[propName];
+	      if (propName === 'target') {
+	        this.target = nativeEventTarget;
+	      } else {
+	        this[propName] = nativeEvent[propName];
+	      }
 	    }
 	  }
 
@@ -13260,7 +13263,10 @@
 	      }
 	    });
 
-	    nativeProps.children = content;
+	    if (content) {
+	      nativeProps.children = content;
+	    }
+
 	    return nativeProps;
 	  }
 
@@ -18733,7 +18739,7 @@
 
 	'use strict';
 
-	module.exports = '0.14.6';
+	module.exports = '0.14.7';
 
 /***/ },
 /* 147 */
@@ -20200,33 +20206,55 @@
 				_react2.default.createElement('div', { className: 'ReactCrop--drag-handle ord-w', 'data-ord': 'w' })
 			);
 		},
+		arrayDividedBy100: function arrayDividedBy100(arr, delimeter) {
+			delimeter = delimeter || ' ';
+			return arr.map(function (number) {
+				return number / 100;
+			}).join(delimeter);
+		},
 		arrayToPercent: function arrayToPercent(arr, delimeter) {
 			delimeter = delimeter || ' ';
 			return arr.map(function (number) {
 				return number + '%';
 			}).join(delimeter);
 		},
-		getImageClipStyle: function getImageClipStyle() {
+		getPolygonValues: function getPolygonValues(forSvg) {
 			var crop = this.state.crop;
+			var pTopLeft = [crop.x, crop.y];
+			var pTopRight = [crop.x + crop.width, crop.y];
+			var pBottomLeft = [crop.x, crop.y + crop.height];
+			var pBottomRight = [crop.x + crop.width, crop.y + crop.height];
 
-			var right = 100 - (crop.x + crop.width);
-			var bottom = 100 - (crop.y + crop.height);
-
-			// Safari doesn't like it if values add up to exactly
-			// 100 (it doesn't draw the clip). I have submitted a bug.
-			if (crop.x + right === 100) {
-				right -= 0.00001;
+			if (forSvg) {
+				pTopLeft = this.arrayDividedBy100(pTopLeft);
+				pTopRight = this.arrayDividedBy100(pTopRight);
+				pBottomLeft = this.arrayDividedBy100(pBottomLeft);
+				pBottomRight = this.arrayDividedBy100(pBottomRight);
+			} else {
+				pTopLeft = this.arrayToPercent(pTopLeft);
+				pTopRight = this.arrayToPercent(pTopRight);
+				pBottomLeft = this.arrayToPercent(pBottomLeft);
+				pBottomRight = this.arrayToPercent(pBottomRight);
 			}
+			return {
+				top: {
+					left: pTopLeft,
+					right: pTopRight
+				},
+				bottom: {
+					left: pBottomLeft,
+					right: pBottomRight
+				}
+			};
+		},
+		getImageClipStyle: function getImageClipStyle() {
+			var polygon = this.getPolygonValues();
 
-			if (crop.y + bottom === 100) {
-				bottom -= 0.00001;
-			}
-
-			var insetVal = 'inset(' + this.arrayToPercent([crop.y, right, bottom, crop.x]) + ')';
+			var polygonVal = 'polygon(' + polygon.top.left + ', ' + polygon.top.right + ', ' + polygon.bottom.right + ', ' + polygon.bottom.left + ')';
 
 			return {
-				WebkitClipPath: insetVal,
-				clipPath: insetVal
+				WebkitClipPath: polygonVal,
+				clipPath: 'url("#ReactCropperClipPolygon")'
 			};
 		},
 		onImageLoad: function onImageLoad(e) {
@@ -20261,6 +20289,20 @@
 				crop.height = crop.width / crop.aspect * imageAspect;
 			}
 		},
+		getClipPathHtml: function getClipPathHtml() {
+			var polygon = this.getPolygonValues(true);
+			// We used dangerouslySetInnerHTML because react refuses to add the attribute 'clipPathUnits' to the rendered DOM
+			return {
+				__html: '<clipPath id="ReactCropperClipPolygon" clipPathUnits="objectBoundingBox">' + ('<polygon points="' + polygon.top.left + ', ' + polygon.top.right + ', ' + polygon.bottom.right + ', ' + polygon.bottom.left + '" />') + '</clipPath>'
+			};
+		},
+		renderSvg: function renderSvg() {
+			return _react2.default.createElement(
+				'svg',
+				{ width: '0', height: '0', style: { position: 'absolute', top: '0', left: '0' } },
+				_react2.default.createElement('defs', { dangerouslySetInnerHTML: this.getClipPathHtml() })
+			);
+		},
 		render: function render() {
 			var cropSelection = undefined,
 			    imageClip = undefined;
@@ -20287,6 +20329,7 @@
 					onMouseDown: this.onComponentMouseTouchDown,
 					tabIndex: '1',
 					onKeyDown: this.onComponentKeyDown },
+				this.renderSvg(),
 				_react2.default.createElement('img', { ref: 'image', className: 'ReactCrop--image', src: this.props.src, onLoad: this.onImageLoad }),
 				_react2.default.createElement(
 					'div',

--- a/dist/ReactCrop.js
+++ b/dist/ReactCrop.js
@@ -490,14 +490,16 @@ var ReactCrop = _react2.default.createClass({
 			_react2.default.createElement('div', { className: 'ReactCrop--drag-handle ord-w', 'data-ord': 'w' })
 		);
 	},
-	arrayDividedBy100: function arrayDividedBy100(arr, delimeter) {
-		delimeter = delimeter || ' ';
+	arrayDividedBy100: function arrayDividedBy100(arr) {
+		var delimeter = arguments.length <= 1 || arguments[1] === undefined ? ' ' : arguments[1];
+
 		return arr.map(function (number) {
 			return number / 100;
 		}).join(delimeter);
 	},
-	arrayToPercent: function arrayToPercent(arr, delimeter) {
-		delimeter = delimeter || ' ';
+	arrayToPercent: function arrayToPercent(arr) {
+		var delimeter = arguments.length <= 1 || arguments[1] === undefined ? ' ' : arguments[1];
+
 		return arr.map(function (number) {
 			return number + '%';
 		}).join(delimeter);
@@ -531,15 +533,13 @@ var ReactCrop = _react2.default.createClass({
 			}
 		};
 	},
-	getImageClipStyle: function getImageClipStyle() {
-		var polygon = this.getPolygonValues();
+	getPolygonClipPath: function getPolygonClipPath() {
+		var _getPolygonValues = this.getPolygonValues();
 
-		var polygonVal = 'polygon(' + polygon.top.left + ', ' + polygon.top.right + ', ' + polygon.bottom.right + ', ' + polygon.bottom.left + ')';
+		var top = _getPolygonValues.top;
+		var bottom = _getPolygonValues.bottom;
 
-		return {
-			WebkitClipPath: polygonVal,
-			clipPath: 'url("#ReactCropperClipPolygon")'
-		};
+		return 'polygon(' + top.left + ', ' + top.right + ', ' + bottom.right + ', ' + bottom.left + ')';
 	},
 	onImageLoad: function onImageLoad(e) {
 		var crop = this.state.crop;
@@ -573,11 +573,17 @@ var ReactCrop = _react2.default.createClass({
 			crop.height = crop.width / crop.aspect * imageAspect;
 		}
 	},
+
+
+	// We used dangerouslySetInnerHTML because react refuses to add the attribute 'clipPathUnits' to the rendered DOM
 	getClipPathHtml: function getClipPathHtml() {
-		var polygon = this.getPolygonValues(true);
-		// We used dangerouslySetInnerHTML because react refuses to add the attribute 'clipPathUnits' to the rendered DOM
+		var _getPolygonValues2 = this.getPolygonValues(true);
+
+		var top = _getPolygonValues2.top;
+		var bottom = _getPolygonValues2.bottom;
+
 		return {
-			__html: '<clipPath id="ReactCropperClipPolygon" clipPathUnits="objectBoundingBox">' + ('<polygon points="' + polygon.top.left + ', ' + polygon.top.right + ', ' + polygon.bottom.right + ', ' + polygon.bottom.left + '" />') + '</clipPath>'
+			__html: '<clipPath id="ReactCropperClipPolygon" clipPathUnits="objectBoundingBox">\n\t\t\t\t\t\t\t\t<polygon points="' + top.left + ', ' + top.right + ', ' + bottom.right + ', ' + bottom.left + '" />\n\t\t\t\t\t\t\t</clipPath>'
 		};
 	},
 	renderSvg: function renderSvg() {
@@ -593,7 +599,10 @@ var ReactCrop = _react2.default.createClass({
 
 		if (!this.cropInvalid) {
 			cropSelection = this.createCropSelection();
-			imageClip = this.getImageClipStyle();
+			imageClip = {
+				WebkitClipPath: this.getPolygonClipPath(),
+				clipPath: 'url("#ReactCropperClipPolygon")'
+			};
 		}
 
 		var componentClasses = ['ReactCrop'];

--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -509,13 +509,11 @@ var ReactCrop = React.createClass({
 		);
 	},
 
-	arrayDividedBy100(arr, delimeter) {
-		delimeter = delimeter || ' ';
+	arrayDividedBy100(arr, delimeter = ' ') {
 		return arr.map(number => number / 100).join(delimeter);
 	},
 
-	arrayToPercent(arr, delimeter) {
-		delimeter = delimeter || ' ';
+	arrayToPercent(arr, delimeter = ' ') {
 		return arr.map(number => number + '%').join(delimeter);
 	},
 
@@ -549,15 +547,9 @@ var ReactCrop = React.createClass({
 		};
 	},
 
-	getImageClipStyle() {
-		let polygon = this.getPolygonValues();
-
-		let polygonVal = `polygon(${polygon.top.left}, ${polygon.top.right}, ${polygon.bottom.right}, ${polygon.bottom.left})`;
-
-		return {
-			WebkitClipPath: polygonVal,
-			clipPath: 'url("#ReactCropperClipPolygon")'
-		};
+	getPolygonClipPath() {
+		let { top, bottom } = this.getPolygonValues();
+		return `polygon(${top.left}, ${top.right}, ${bottom.right}, ${bottom.left})`;
 	},
 
 	onImageLoad(e) {
@@ -594,13 +586,13 @@ var ReactCrop = React.createClass({
 		}
 	},
 
+	// We used dangerouslySetInnerHTML because react refuses to add the attribute 'clipPathUnits' to the rendered DOM
 	getClipPathHtml() {
-		let polygon = this.getPolygonValues(true);
-		// We used dangerouslySetInnerHTML because react refuses to add the attribute 'clipPathUnits' to the rendered DOM
+		let { top, bottom } = this.getPolygonValues(true);
 		return {
-			__html: '<clipPath id="ReactCropperClipPolygon" clipPathUnits="objectBoundingBox">' +
-						`<polygon points="${polygon.top.left}, ${polygon.top.right}, ${polygon.bottom.right}, ${polygon.bottom.left}" />` +
-					'</clipPath>'
+			__html: `<clipPath id="ReactCropperClipPolygon" clipPathUnits="objectBoundingBox">
+								<polygon points="${top.left}, ${top.right}, ${bottom.right}, ${bottom.left}" />
+							</clipPath>`
 		};
 	},
 
@@ -617,7 +609,10 @@ var ReactCrop = React.createClass({
 
 		if (!this.cropInvalid) {
 			cropSelection = this.createCropSelection();
-			imageClip = this.getImageClipStyle();
+			imageClip = {
+				WebkitClipPath: this.getPolygonClipPath(),
+				clipPath: 'url("#ReactCropperClipPolygon")'
+			};
 		}
 
 		let componentClasses = ['ReactCrop'];


### PR DESCRIPTION
@DominicTobias can you take a look at this please?
I've created a SVG and that's the used element to create the Clip-Path as Firefox hates the idea of polygon or inset in the clip-path property.
Now the real question is, if we're going with this solution, shouldn't it be the same for WebKit?
Should we remove the `-webkit-clip-path: polygon(...)` and keep it as `-webkip-clip-path: url("#...")`?
Also, I've tested this solution on Safari and having the values as `100%` still renders perfectly.

TL;DR: Give me thoughts, not sure if this solution should be final.