### PR TITLE
Add max-width 100 and pass the image DOM element to onImageLoaded for…

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ A callback which happens for every change of the crop (i.e. many times as you ar
 
 A callback which happens after a resize, drag, or nudge. Passes the current crop state object.
 
-#### onImageLoaded(crop) (optional)
+#### onImageLoaded(crop, image) (optional)
 
-A callback which happens when the image is loaded. Passes the current crop state object.
+A callback which happens when the image is loaded. Passes the current crop state object and the image DOM element.
 
 ## What about showing the crop on the client?
 

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -2,7 +2,3 @@ html,
 body {
 	margin: 0;
 }
-
-img {
-	max-width: 100%;
-}

--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -529,8 +529,9 @@ const ReactCrop = React.createClass({
 
 	onImageLoad(e) {
 		const crop = this.state.crop;
-		const imageWidth = e.target.naturalWidth;
-		const imageHeight = e.target.naturalHeight;
+		const image = e.target;
+		const imageWidth = image.naturalWidth;
+		const imageHeight = image.naturalHeight;
 		const imageAspect = imageWidth / imageHeight;
 
 		// If there is a width or height then infer the other to
@@ -546,7 +547,7 @@ const ReactCrop = React.createClass({
 			this.setState({ crop: crop });
 		}
 		if (this.props.onImageLoaded) {
-			this.props.onImageLoaded(crop);
+			this.props.onImageLoaded(crop, image);
 		}
 	},
 

--- a/lib/ReactCrop.scss
+++ b/lib/ReactCrop.scss
@@ -28,11 +28,13 @@ $drag-bar-mobile-size: $drag-bar-size + 8;
 
 .ReactCrop--image {
 	display: block;
+	max-width: 100%;
 }
 .ReactCrop--image-copy {
 	position: absolute;
 	top: 0;
 	left: 0;
+	max-width: 100%;
 }
 
 .ReactCrop--crop-wrapper {


### PR DESCRIPTION
… issue #21

I think we can avoid the max-width issue which is probably what people want, as it's non-obvious that it needs to be applied to the image copy too (actually I didn't realise either, good spot!). Also passing the image DOM element to the loaded callback could help if someone wants to set a dynamic crop based on the image dimensions?

@DPr00f 