### PR TITLE
Fix for ISSUE-24: Order issue with Object.Assign in getInitialState

### DIFF
--- a/dist/ReactCrop.js
+++ b/dist/ReactCrop.js
@@ -51,7 +51,7 @@ var ReactCrop = _react2.default.createClass({
 	getInitialState: function getInitialState() {
 		var props = arguments.length <= 0 || arguments[0] === undefined ? this.props : arguments[0];
 
-		var crop = (0, _objectAssign2.default)({}, this.defaultCrop, props.crop, this.state ? this.state.crop : {});
+		var crop = (0, _objectAssign2.default)({}, this.defaultCrop, this.state ? this.state.crop : {}, props.crop);
 
 		this.cropInvalid = !crop.width || !crop.height;
 


### PR DESCRIPTION
In the componentWillRecieveProps method, the newProps are spread across the existing state using Object.Assign. The order that the properties are assigned causes new props to be overwritten by existing ones if they are already present in the state. Rearranged these so that the new props are always assigned last, thus overriding existing values in the state.

Address Issue https://github.com/DominicTobias/react-image-crop/issues/24