### PR TITLE
Merge props.crop into the state object last so that it takes precedence over state

### DIFF
--- a/demo/bundle.js
+++ b/demo/bundle.js
@@ -88,14 +88,48 @@
 	var cropEditor = document.querySelector('#crop-editor');
 
 	function loadEditView(dataUrl) {
-		// Pass in with crop={crop}.
-		var crop = {
-			x: 20,
-			y: 10,
-			width: 60,
-			aspect: 3 / 4
-		};
-		_reactDom2.default.render(_react2.default.createElement(_ReactCrop2.default, { crop: crop, src: dataUrl, onImageLoaded: onImageLoaded, onComplete: onCropComplete }), cropEditor);
+
+		var Parent = _react2.default.createClass({
+			displayName: 'Parent',
+
+			getInitialState: function getInitialState() {
+				return {
+					crop: {
+						x: 0,
+						y: 0,
+						aspect: 16 / 9,
+						width: 50
+					}
+				};
+			},
+
+			onButtonClick: function onButtonClick() {
+				this.setState({
+					crop: {
+						x: 20,
+						y: 5,
+						aspect: false,
+						width: 30,
+						height: 50
+					}
+				});
+			},
+
+			render: function render() {
+				return _react2.default.createElement(
+					'div',
+					null,
+					_react2.default.createElement(_ReactCrop2.default, { crop: this.state.crop, src: dataUrl, onImageLoaded: onImageLoaded, onComplete: onCropComplete }),
+					_react2.default.createElement(
+						'button',
+						{ onClick: this.onButtonClick },
+						'Programatically set crop'
+					)
+				);
+			}
+		});
+
+		_reactDom2.default.render(_react2.default.createElement(Parent, null), cropEditor);
 	}
 
 	function onImageLoaded(crop) {
@@ -19733,6 +19767,7 @@
 	var ReactCrop = _react2.default.createClass({
 		displayName: 'ReactCrop',
 
+
 		propTypes: {
 			src: _react2.default.PropTypes.string.isRequired,
 			crop: _react2.default.PropTypes.object,
@@ -19766,7 +19801,7 @@
 		getInitialState: function getInitialState() {
 			var props = arguments.length <= 0 || arguments[0] === undefined ? this.props : arguments[0];
 
-			var crop = (0, _objectAssign2.default)({}, this.defaultCrop, props.crop, this.state ? this.state.crop : {});
+			var crop = (0, _objectAssign2.default)({}, this.defaultCrop, props.crop);
 
 			this.cropInvalid = !crop.width || !crop.height;
 
@@ -20236,8 +20271,9 @@
 		},
 		onImageLoad: function onImageLoad(e) {
 			var crop = this.state.crop;
-			var imageWidth = e.target.naturalWidth;
-			var imageHeight = e.target.naturalHeight;
+			var image = e.target;
+			var imageWidth = image.naturalWidth;
+			var imageHeight = image.naturalHeight;
 			var imageAspect = imageWidth / imageHeight;
 
 			// If there is a width or height then infer the other to
@@ -20253,7 +20289,7 @@
 				this.setState({ crop: crop });
 			}
 			if (this.props.onImageLoaded) {
-				this.props.onImageLoaded(crop);
+				this.props.onImageLoaded(crop, image);
 			}
 		},
 		adjustOnImageLoadCrop: function adjustOnImageLoadCrop(crop, imageAspect) {
@@ -20266,6 +20302,7 @@
 				crop.height = crop.width / crop.aspect * imageAspect;
 			}
 		},
+
 
 		// We used dangerouslySetInnerHTML because react refuses to add the attribute 'clipPathUnits' to the rendered DOM
 		getClipPathHtml: function getClipPathHtml() {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -30,14 +30,42 @@ fileInput.addEventListener('change', function(e) {
 var cropEditor = document.querySelector('#crop-editor');
 
 function loadEditView(dataUrl) {
-	// Pass in with crop={crop}.
-	var crop = {
-		x: 20,
-		y: 10,
-		width: 60,
-		aspect: 3/4
-	};
-	ReactDOM.render(<ReactCrop crop={crop} src={dataUrl} onImageLoaded={onImageLoaded} onComplete={onCropComplete} />, cropEditor);
+	
+	var Parent = React.createClass({
+		getInitialState: function() {
+			return {
+				crop: {
+					x: 0,
+					y: 0,		
+					aspect: 16/9,
+					width: 50
+				}
+			};
+		},
+
+		onButtonClick: function() {
+			this.setState({
+				crop: {
+					x: 20,
+					y: 5,		
+					aspect: false,
+					width: 30,
+					height: 50
+				}
+			});
+		},
+
+		render: function() {
+			return (
+				<div>
+					<ReactCrop crop={this.state.crop} src={dataUrl} onImageLoaded={onImageLoaded} onComplete={onCropComplete} />
+					<button onClick={this.onButtonClick}>Programatically set crop</button>
+				</div>
+			);
+		}
+	});
+
+	ReactDOM.render(<Parent />, cropEditor);
 }
 
 function onImageLoaded(crop) {

--- a/dist/ReactCrop.js
+++ b/dist/ReactCrop.js
@@ -45,13 +45,14 @@ var ReactCrop = _react2.default.createClass({
 		x: 0,
 		y: 0,
 		width: 0,
-		height: 0
+		height: 0,
+		aspect: false
 	},
 
 	getInitialState: function getInitialState() {
 		var props = arguments.length <= 0 || arguments[0] === undefined ? this.props : arguments[0];
 
-		var crop = (0, _objectAssign2.default)({}, this.defaultCrop, this.state ? this.state.crop : {}, props.crop);
+		var crop = (0, _objectAssign2.default)({}, this.defaultCrop, props.crop);
 
 		this.cropInvalid = !crop.width || !crop.height;
 

--- a/dist/ReactCrop.js
+++ b/dist/ReactCrop.js
@@ -51,7 +51,7 @@ var ReactCrop = _react2.default.createClass({
 	getInitialState: function getInitialState() {
 		var props = arguments.length <= 0 || arguments[0] === undefined ? this.props : arguments[0];
 
-		var crop = (0, _objectAssign2.default)({}, this.defaultCrop, props.crop, this.state ? this.state.crop : {});
+		var crop = (0, _objectAssign2.default)({}, this.defaultCrop, this.state ? this.state.crop : {}, props.crop);
 
 		this.cropInvalid = !crop.width || !crop.height;
 

--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -30,11 +30,12 @@ const ReactCrop = React.createClass({
 		x: 0,
 		y: 0,
 		width: 0,
-		height: 0
+		height: 0,
+		aspect: false
 	},
 
 	getInitialState(props = this.props) {
-		const crop = assign({}, this.defaultCrop, this.state ? this.state.crop : {}, props.crop);
+		const crop = assign({}, this.defaultCrop, props.crop);
 
 		this.cropInvalid = (!crop.width || !crop.height);
 

--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -34,7 +34,7 @@ const ReactCrop = React.createClass({
 	},
 
 	getInitialState(props = this.props) {
-		const crop = assign({}, this.defaultCrop, props.crop, this.state ? this.state.crop : {});
+		const crop = assign({}, this.defaultCrop, this.state ? this.state.crop : {}, props.crop);
 
 		this.cropInvalid = (!crop.width || !crop.height);
 


### PR DESCRIPTION
@DPr00f you added `this.state.crop` to the object merge - do you see a problem with changing the order (`props.crop` last)?

On a side note I'm not exactly sure why `this.state` needed to be merged in - you found a bug there #8 - I need to take a deeper look but I guess that `this.state.crop` is not being correctly created after a second parent render without it. I was wondering because maybe the next prop could intentionally omit something (like width or height if aspect is provided) and it could wrongly inherit the width/height from the state object.