### PR TITLE
"without Babel" usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Include the main js module, e.g.:
 
 ```js
 var ReactCrop = require('react-image-crop');
+//without Babel
+var ReactCrop = require('react-image-crop').default;
 // or es6:
 import ReactCrop from 'react-image-crop';
 ```


### PR DESCRIPTION
I ran into errors trying to require the package as described in the docs. After some logging I realized that the package required was just an object, not the React component it's supposed to be. I dropped a screenshot below of that ES6 module object and the errors.

After some research, I found this thread: https://github.com/Microsoft/TypeScript/issues/2719. In there someone mentions that babel automatically points the require to `default`. I'm not using babel to transpile atm (using `reactify` to handle my jsx), so I guessed that was the issue.

Works for me with the `.default`

_(`UploadImage` is the one rendering `ReactCrop`)_

![](http://i.imgur.com/oehVh30.png)