### PR TITLE
Fix broken in IE10

### DIFF
--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -63,7 +63,7 @@ class ReactCrop extends Component {
     this.onCropMouseTouchDown = this.onCropMouseTouchDown.bind(this);
 
     this.state = {
-      crop: this.nextCropState(this.props.crop),
+      crop: this.nextCropState(props.crop),
       polygonId: this.getRandomInt(1, 900000),
     };
   }


### PR DESCRIPTION
Hi! Using `this.props.crop` on constructor is wrong.

[Check ReactJS Doc](https://facebook.github.io/react/docs/reusable-components.html#es6-classes)

That will cause IE10 throw error: Unable to get property 'crop' of undefined or null reference.

### how to replicate ###

Open demo/index.html on IE10.