### PR TITLE
Passing crossorigin attribute as props to component. Allows usage of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ A callback which happens when the image is loaded. Passes the current crop state
 
 *Note* that when setting state in a callback you must also ensure that you set the new crop state, otherwise your component will re-render with whatever crop state was initially set.
 
+#### crossorigin (optional)
+
+Allows to set the crossorigin attribute used for the img tag. Default value is ``anonymous```. Other option would be __use-credentials__
+
+
 #### ellipse (optional)
 
 If true, the selection will have an ellipse shape rather than a rectangular one. If a fixed aspect ratio is also specified, the shape will be strictly circular.

--- a/dist/ReactCrop.js
+++ b/dist/ReactCrop.js
@@ -74,7 +74,7 @@ module.exports =
 	  function ReactCrop(props) {
 	    _classCallCheck(this, ReactCrop);
 
-	    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(ReactCrop).call(this, props));
+	    var _this = _possibleConstructorReturn(this, (ReactCrop.__proto__ || Object.getPrototypeOf(ReactCrop)).call(this, props));
 
 	    _this.onDocMouseTouchMove = _this.onDocMouseTouchMove.bind(_this);
 	    _this.onDocMouseTouchEnd = _this.onDocMouseTouchEnd.bind(_this);
@@ -84,7 +84,7 @@ module.exports =
 	    _this.onCropMouseTouchDown = _this.onCropMouseTouchDown.bind(_this);
 
 	    _this.state = {
-	      crop: _this.nextCropState(_this.props.crop),
+	      crop: _this.nextCropState(props.crop),
 	      polygonId: _this.getRandomInt(1, 900000)
 	    };
 	    return _this;
@@ -849,7 +849,7 @@ module.exports =
 	          ref: function ref(c) {
 	            _this4.imageRef = c;
 	          },
-	          crossOrigin: 'anonymous',
+	          crossorigin: this.props.src.indexOf('data:') === -1 ? this.props.crossorigin : undefined,
 	          className: 'ReactCrop--image',
 	          src: this.props.src,
 	          onLoad: function onLoad(e) {
@@ -897,12 +897,14 @@ module.exports =
 	  onImageLoaded: _react.PropTypes.func,
 	  disabled: _react.PropTypes.bool,
 	  ellipse: _react.PropTypes.bool,
+	  crossorigin: _react.PropTypes.string,
 	  children: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.arrayOf(_react2.default.PropTypes.node), _react2.default.PropTypes.node])
 	};
 	ReactCrop.defaultProps = {
 	  disabled: false,
 	  maxWidth: 100,
-	  maxHeight: 100
+	  maxHeight: 100,
+	  crossorigin: 'anonymous'
 	};
 	ReactCrop.xOrds = ['e', 'w'];
 	ReactCrop.yOrds = ['n', 's'];

--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -768,7 +768,7 @@ class ReactCrop extends Component {
           ref={(c) => {
             this.imageRef = c;
           }}
-          crossorigin={(this.props.src.indexOf('data:') === -1) ? this.props.crossorigin : undefined;}
+          crossorigin={(this.props.src.indexOf('data:') === -1) ? this.props.crossorigin : undefined}
           className="ReactCrop--image"
           src={this.props.src}
           onLoad={(e) => { this.onImageLoad(e.target); }}

--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -19,6 +19,7 @@ class ReactCrop extends Component {
     onImageLoaded: PropTypes.func,
     disabled: PropTypes.bool,
     ellipse: PropTypes.bool,
+    crossorigin: PropTypes.string,
     children: React.PropTypes.oneOfType([
       React.PropTypes.arrayOf(React.PropTypes.node),
       React.PropTypes.node,
@@ -29,6 +30,7 @@ class ReactCrop extends Component {
     disabled: false,
     maxWidth: 100,
     maxHeight: 100,
+    crossorigin: 'anonymous'
   }
 
   static xOrds = ['e', 'w']
@@ -766,7 +768,7 @@ class ReactCrop extends Component {
           ref={(c) => {
             this.imageRef = c;
           }}
-          crossorigin={(this.props.src.indexOf('data:') === -1) ? 'anonymous' : undefined;}
+          crossorigin={(this.props.src.indexOf('data:') === -1) ? this.props.crossorigin : undefined;}
           className="ReactCrop--image"
           src={this.props.src}
           onLoad={(e) => { this.onImageLoad(e.target); }}


### PR DESCRIPTION
…use-credentials to retrieve the image. Defaults to anonymous



Instead of hardcoding CORS value for img tag, setting default to anonymous and allowing to pass via props would be more generic and keep current behaviour.

Proposed fix for #65


Hi what do you think for this feature, we need it as our images require credentials beeing sent. Please let me know if this works for you.

Thanks 