### PR TITLE
Add no crossorigin for DataUrls and add crossorigin props if not a Da…

### DIFF
--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -769,7 +769,7 @@ class ReactCrop extends Component {
           ref={(c) => {
             this.imageRef = c;
           }}
-          crossOrigin={isDataUrl ? this.props.crossorigin : undefined}
+          crossOrigin={isDataUrl ? undefined : this.props.crossorigin}
           className="ReactCrop--image"
           src={this.props.src}
           onLoad={(e) => this.onImageLoad(e.target)}
@@ -786,6 +786,7 @@ class ReactCrop extends Component {
             ref={(c) => {
               this.imageCopyRef = c;
             }}
+            crossOrigin={isDataUrl ? undefined : this.props.crossorigin}
             className="ReactCrop--image-copy"
             src={this.props.src}
             style={imageClip}


### PR DESCRIPTION
…taUrl is given in src, Adding crossorigin attribute to second image to avoid duplicate calls in case when crossorigin is specified. Image is then loaded twice from server

Hi @DominicTobias , sorry for this commit, but I think with your last commit the logic was changed, so that the crossorigin props was only added when the src was actually a DataUrl. The check changed from is it not a DataUrl to is it a DataUrl.

Or was it intentionally?

Closing issue #66 