### PR TITLE
Support for scaled down crop images

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ A maximum crop width.
 
 A maximum crop height.
 
+#### originalWidth (optional, use together with originalHeight)
+
+If you're using a scaled down version of an original image, originalWidth lets you specify the width of the original image so you can get the pixel-converted values for the original image instead of values for the scaled down image.
+
+#### originalHeight (optional, use together with originalWidth)
+
+If you're using a scaled down version of an original image, originalHeight lets you specify the height of the original image so you can get the pixel-converted values for the original image instead of values for the scaled down image.
+
 #### keepSelection (optional)
 
 If true is passed then selection can't be disabled if the user clicks outside the selection area.

--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -13,6 +13,8 @@ class ReactCrop extends Component {
     minHeight: PropTypes.number,
     maxWidth: PropTypes.number,
     maxHeight: PropTypes.number,
+    originalWidth: PropTypes.number,
+    originalHeight: PropTypes.number,
     keepSelection: PropTypes.bool,
     onChange: PropTypes.func,
     onComplete: PropTypes.func,
@@ -63,6 +65,7 @@ class ReactCrop extends Component {
     this.onComponentMouseTouchDown = this.onComponentMouseTouchDown.bind(this);
     this.onComponentKeyDown = this.onComponentKeyDown.bind(this);
     this.onCropMouseTouchDown = this.onCropMouseTouchDown.bind(this);
+    this.getPixelCrop = this.getPixelCrop.bind(this);
 
     this.state = {
       crop: this.nextCropState(props.crop),
@@ -313,11 +316,17 @@ class ReactCrop extends Component {
   }
 
   getPixelCrop(crop) {
+    let { originalWidth: width, originalHeight: height } = this.props;
+    if(!width || !height) {
+      width = this.imageRef.naturalWidth;
+      height = this.imageRef.naturalHeight;
+    }
+ 
     return {
-      x: Math.round(this.imageRef.naturalWidth * (crop.x / 100)),
-      y: Math.round(this.imageRef.naturalHeight * (crop.y / 100)),
-      width: Math.round(this.imageRef.naturalWidth * (crop.width / 100)),
-      height: Math.round(this.imageRef.naturalHeight * (crop.height / 100)),
+      x: Math.round(width * (crop.x / 100)),
+      y: Math.round(height * (crop.y / 100)),
+      width: Math.round(width * (crop.width / 100)),
+      height: Math.round(height * (crop.height / 100)),
     };
   }
 


### PR DESCRIPTION
When working with very large images it's not uncommon to have a scaled down version of the image, generated on the fly and cached by a server, sent to the browser to keep payload sizes reasonable.

By adding `originalWidth` and `originalHeight` props we can let `getPixelCrop()` return crop pixel values for the original image instead of the naturalHeight/naturalWidth of the scaled down image sent to the browser.

If either the originalWidth or the originalHeight prop is missing we fall back to the current functionality (using naturalHeight/naturalWidth) to prevent weird results.