### PR TITLE
Fixes dragging x or y handle offscreen

### DIFF
--- a/lib/ReactCrop.jsx
+++ b/lib/ReactCrop.jsx
@@ -534,16 +534,18 @@ class ReactCrop extends Component {
       }
     }
 
-    crop.x = this.clamp(newX, 0, 100 - newSize.width);
-    crop.y = this.clamp(newY, 0, 100 - newSize.height);
-
-    // Apply width/height changes depending on ordinate (fixed aspect always applies both).
+    // Apply x/y/width/height changes depending on ordinate (fixed aspect always applies both).
     if (crop.aspect || ReactCrop.xyOrds.indexOf(ord) > -1) {
+      crop.x = this.clamp(newX, 0, 100 - newSize.width);
+      crop.y = this.clamp(newY, 0, 100 - newSize.height);
+
       crop.width = newSize.width;
       crop.height = newSize.height;
     } else if (ReactCrop.xOrds.indexOf(ord) > -1) {
+      crop.x = this.clamp(newX, 0, 100 - newSize.width);
       crop.width = newSize.width;
     } else if (ReactCrop.yOrds.indexOf(ord) > -1) {
+      crop.y = this.clamp(newY, 0, 100 - newSize.height);
       crop.height = newSize.height;
     }
 


### PR DESCRIPTION
Tricky bug to explain, here is a gif of the fix (expected behaviour):

![fixed-x-axis-dragging](https://cloud.githubusercontent.com/assets/907140/20048343/09462d90-a510-11e6-9ba3-e79a3d7b9d56.gif)

Actual behaviour on master, is grabbing an "x" handle and dragging it off the top or bottom (as shown) will move the crop area vertically, where it should not. Similarly, grabbing a "y" handle and dragging off canvas will reposition the crop on the x axis.