### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If true then the user cannot modify or draw a new crop. A class of `ReactCrop--d
 
 #### onChange(crop, pixelCrop) (optional)
 
-A callback which happens for every change of the crop (i.e. many times as you are dragging/resizing). Passes the current crop state object, as well as a pixel-converted crop for your convenience.
+A callback which happens for every change of the crop (i.e. many times as you are dragging/resizing). Passes the current crop state object, as well as a pixel-converted crop for your convenience. This is not called on the load even if the crop was adjusted.
 
 *Note* that when setting state in a callback you must also ensure that you set the new crop state, otherwise your component will re-render with whatever crop state was initially set.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If true then the user cannot modify or draw a new crop. A class of `ReactCrop--d
 
 #### onChange(crop, pixelCrop) (optional)
 
-A callback which happens for every change of the crop (i.e. many times as you are dragging/resizing). Passes the current crop state object, as well as a pixel-converted crop for your convenience. This is not called on the load even if the crop was adjusted.
+A callback which happens for every change of the crop (i.e. many times as you are dragging/resizing). Passes the current crop state object, as well as a pixel-converted crop for your convenience. This callback is not called on the load even if the crop was adjusted.
 
 *Note* that when setting state in a callback you must also ensure that you set the new crop state, otherwise your component will re-render with whatever crop state was initially set.
 
@@ -107,7 +107,7 @@ A callback which happens after a resize, drag, or nudge. Passes the current crop
 
 #### onImageLoaded(crop, image, pixelCrop) (optional)
 
-A callback which happens when the image is loaded. Passes the current crop state object and the image DOM element, as well as a pixel-converted crop for your convenience.
+A callback which happens when the image is loaded. Passes the current crop state object and the image DOM element, as well as a pixel-converted crop for your convenience. If the crop was adjusted during the load, this callback gives you the adjusted crop.
 
 *Note* that when setting state in a callback you must also ensure that you set the new crop state, otherwise your component will re-render with whatever crop state was initially set.
 


### PR DESCRIPTION
onChange is not called on the load even if the crop was adjusted. This is so that we can detect user changes using this callback as opposed to changes (adjustments) made by the library during the initialization.

Close #99