### PR TITLE
Issue #108: Add in optional imageHeight and imageWidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ A callback which happens when a user releases the cursor or touch after dragging
 
 Allows setting the crossorigin attribute used for the img tags.
 
+#### imageHeight, imageWidth (optional)
+
+Allows you to set the height and width of the image to crop (a number, in pixels). Returned crop values will be relative to these dimensions, not the dimensions of the original image.
+
 ## What about showing the crop on the client?
 
 I wanted to keep this component focused so I didn't provide this. Normally a cropped image will be rendered and cached by a backend. However here are some tips for client-side crop previews:

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 const EMPTY_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+let originalImageHeight;
+let originalImageWidth;
 
 function getElementOffset(el) {
   const rect = el.getBoundingClientRect();
@@ -58,8 +60,8 @@ function inverseOrd(ord) {
 }
 
 function ensureAspectDimensions(cropObj, imageEl) {
-  const imageWidth = imageEl.naturalWidth;
-  const imageHeight = imageEl.naturalHeight;
+  const imageWidth = imageEl.width;
+  const imageHeight = imageEl.height;
   const imageAspect = imageWidth / imageHeight;
   const crop = { ...cropObj };
 
@@ -92,6 +94,8 @@ class ReactCrop extends Component {
       height: PropTypes.number,
     }),
     imageAlt: PropTypes.string,
+    imageWidth: PropTypes.number,
+    imageHeight: PropTypes.number,
     minWidth: PropTypes.number,
     minHeight: PropTypes.number,
     maxWidth: PropTypes.number,
@@ -116,6 +120,8 @@ class ReactCrop extends Component {
     crossorigin: undefined,
     disabled: false,
     imageAlt: '',
+    imageWidth: undefined,
+    imageHeight: undefined,
     maxWidth: 100,
     maxHeight: 100,
     minWidth: 0,
@@ -183,6 +189,8 @@ class ReactCrop extends Component {
         this.imageRef.src = EMPTY_GIF;
         this.imageRef.src = src;
       } else {
+        originalImageHeight = this.imageRef.naturalHeight;
+        originalImageWidth = this.imageRef.naturalWidth;
         // Fixme: this is causing a double onImageLoaded event in normal cases.
         this.onImageLoad(this.imageRef);
       }
@@ -422,10 +430,10 @@ class ReactCrop extends Component {
 
   getPixelCrop(crop) {
     return {
-      x: Math.round(this.imageRef.naturalWidth * (crop.x / 100)),
-      y: Math.round(this.imageRef.naturalHeight * (crop.y / 100)),
-      width: Math.round(this.imageRef.naturalWidth * (crop.width / 100)),
-      height: Math.round(this.imageRef.naturalHeight * (crop.height / 100)),
+      x: Math.round(this.imageRef.width * (crop.x / 100)),
+      y: Math.round(this.imageRef.height * (crop.y / 100)),
+      width: Math.round(this.imageRef.width * (crop.width / 100)),
+      height: Math.round(this.imageRef.height * (crop.height / 100)),
     };
   }
 
@@ -666,6 +674,8 @@ class ReactCrop extends Component {
       >
         <img
           ref={n => (this.imageRef = n)}
+          height={this.props.imageHeight || originalImageHeight}
+          width={this.props.imageWidth || originalImageWidth}
           crossOrigin={this.props.crossorigin}
           className="ReactCrop__image"
           src={this.props.src}
@@ -679,6 +689,8 @@ class ReactCrop extends Component {
         >
           <img
             ref={n => (this.imageCopyRef = n)}
+            height={this.props.imageHeight || originalImageHeight}
+            width={this.props.imageWidth || originalImageWidth}
             crossOrigin={this.props.crossorigin}
             className="ReactCrop__image-copy"
             src={this.props.src}


### PR DESCRIPTION
Resolves [Issue 108](https://github.com/DominicTobias/react-image-crop/issues/108)

Currently you can not specify a custom width/height -- you'll always be cropping the full sized image.

This PR introduces 2 new optional props: `imageHeight` and `imageWidth`. This will set the `height` and `width` attributes on the `img` tags. If omitted, these values will fallback to the image's natural dimensions. 

This PR also updates crop calculations using the image's `naturalHeight` and `naturalWidth` properties to instead use `height` and `width` which will pull from the height/width specified on the `img` tag. This will result in the crop ratios being relative to the custom image size rather than the natural image size.