### PR TITLE
Fixes #134: Adding improved CDN/web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ import 'react-image-crop/dist/ReactCrop.css';
 import 'react-image-crop/lib/ReactCrop.scss';
 ```
 
+## CDN
+
+If you prefer to include ReactCrop globally by marking `react-image-crop` as external in your application, then include `react-image-crop` from one of the following CDNs:
+
+* **cdnjs** *(Coming soon)*
+
+* [**unpkg**](https://unpkg.com/react-image-crop/)
+```html
+<script src="https://unpkg.com/react-image-crop/dist/ReactCrop.min.js"></script>
+```
+
 ## Props
 
 #### src (required)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,21 +1,39 @@
 const path = require('path');
+const webpack = require('webpack');
 
-module.exports = {
-  entry: './lib/ReactCrop',
-  output: {
-    path: path.join(__dirname, 'dist'),
-    library: 'ReactCrop',
-    libraryTarget: 'commonjs2',
-    filename: 'ReactCrop.js',
-  },
-  externals: {
-    react: 'react',
-  },
-  module: {
-    loaders: [{
-      test: /\.(js|jsx)$/,
-      exclude: /node_modules/,
-      loader: 'babel-loader',
-    }],
-  },
-};
+function getConfig(minified) {
+  const config = {
+    entry: './lib/ReactCrop',
+    output: {
+      path: path.join(__dirname, 'dist'),
+      library: 'ReactCrop',
+      libraryTarget: 'umd',
+      filename: 'ReactCrop' + (minified ? '.min' : '') + '.js',
+    },
+    target: 'web',
+    externals: {
+      react: 'react',
+    },
+    module: {
+      loaders: [{
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      }],
+    }
+  };
+
+  if (minified) {
+    config.plugins = [
+      new webpack.optimize.ModuleConcatenationPlugin(),
+      new webpack.optimize.UglifyJsPlugin(),
+    ];
+  }
+
+  return config;
+}
+
+module.exports = [
+  getConfig(),
+  getConfig(true),
+];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ function getConfig(minified) {
     },
     target: 'web',
     externals: {
-      react: 'react',
+      react: 'React',
     },
     module: {
       loaders: [{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,9 @@ function getConfig(minified) {
     config.plugins = [
       new webpack.optimize.ModuleConcatenationPlugin(),
       new webpack.optimize.UglifyJsPlugin(),
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      }),
     ];
   }
 


### PR DESCRIPTION
Fixes #134: Adding support for building the release files that target web platform via UMD with both minified and unminified versions. Updated Readme with corresponding CDN information.

Once merged. I will begin the process of getting this library hosted on CDNJS (which is the best CDN) ... slightly faster then unpkg. Once that goes through, I'll submit another PR to include link on Readme.

cc @DominicTobias 