### PR TITLE
Allowed custom styles on image and wrapper elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ If true is passed then selection can't be disabled if the user clicks outside th
 
 If true then the user cannot modify or draw a new crop. A class of `ReactCrop--disabled` is also added to the container for user styling.
 
+#### style (optional)
+
+Inline styles object to be passed to the image wrapper element.
+
+#### imageStyle (optional)
+
+Inline styles object to be passed to the image element.
+
 #### onChange(crop, pixelCrop)
 
 A callback which happens for every change of the crop (i.e. many times as you are dragging/resizing). Passes the current crop state object, as well as a pixel-converted crop for your convenience.

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -585,6 +585,8 @@ class ReactCrop extends PureComponent {
       disabled,
       imageAlt,
       src,
+      style,
+      imageStyle,
     } = this.props;
     const { cropIsActive } = this.state;
     let cropSelection;
@@ -619,6 +621,7 @@ class ReactCrop extends PureComponent {
       <div
         ref={(n) => { this.componentRef = n; }}
         className={componentClasses.join(' ')}
+        style={style}
         onTouchStart={this.onComponentMouseTouchDown}
         onMouseDown={this.onComponentMouseTouchDown}
         tabIndex="1"
@@ -628,6 +631,7 @@ class ReactCrop extends PureComponent {
           ref={(n) => { this.imageRef = n; }}
           crossOrigin={crossorigin}
           className="ReactCrop__image"
+          style={imageStyle}
           src={src}
           onLoad={e => this.onImageLoad(e.target)}
           alt={imageAlt}
@@ -687,6 +691,8 @@ ReactCrop.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
+  style: PropTypes.object,
+  imageStyle: PropTypes.object,
 };
 
 ReactCrop.defaultProps = {
@@ -704,6 +710,8 @@ ReactCrop.defaultProps = {
   onDragStart: () => {},
   onDragEnd: () => {},
   children: undefined,
+  style: undefined,
+  imageStyle: undefined,
 };
 
 module.exports = ReactCrop;


### PR DESCRIPTION
This PR adds the `style` and `imageStyle` props to allow custom inline styles on the `img` and on the wrapper `div`. Along with defaultProps, propTypes and docs.

I haven't updated the `dist/`, I can update the PR if the build is needed.