### PR TITLE
fix(preventDefault): we need to set {passive: false} on touch handlers

### DIFF
--- a/lib/ReactCrop.scss
+++ b/lib/ReactCrop.scss
@@ -17,6 +17,7 @@ $drag-bar-mobile-size: $drag-bar-size + 8;
   overflow: hidden;
   max-width: 100%;
   background-color: #000;
+  touch-action: none;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
we can also set `touch-action: none` on the container, that way we have better browser
compatability, otherwise we would need to check if passive is available via: 
https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection

see: https://www.chromestatus.com/features/5093566007214080
and: https://github.com/bevacqua/dragula/issues/468