### PR TITLE
Accept object for src as well as string

### DIFF
--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -777,7 +777,10 @@ ReactCrop.propTypes = {
   onImageLoaded: PropTypes.func,
   onDragStart: PropTypes.func,
   onDragEnd: PropTypes.func,
-  src: PropTypes.string.isRequired,
+  src: PropTypes.oneOfType([
+    PropTypes.string.isRequired,
+    PropTypes.object.isRequired,
+  ]),
   style: PropTypes.shape({}),
 };
 


### PR DESCRIPTION
According to [the documentation](https://www.npmjs.com/package/react-image-crop#src-required). `src` can be a URL, a data URI or a blob, but these prop types didn't allow `Blob` to be passed in.