### PR TITLE
Pass external window

### DIFF
--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -14,12 +14,13 @@ try {
 
 const EMPTY_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
-function getElementOffset(el) {
+function getElementOffset(el, win) {
   const rect = el.getBoundingClientRect();
-  const docEl = document.documentElement;
+  const clientTop = win.document.clientTop || 0;
+  const clientLeft = win.document.clientLeft || 0;
 
-  const rectTop = (rect.top + window.pageYOffset) - docEl.clientTop;
-  const rectLeft = (rect.left + window.pageXOffset) - docEl.clientLeft;
+  const rectTop = (rect.top + win.pageYOffset) - clientTop;
+  const rectLeft = (rect.left + win.pageXOffset) - clientLeft;
 
   return {
     top: rectTop,
@@ -176,15 +177,25 @@ function containCrop(previousCrop, crop, imageAspect) {
 class ReactCrop extends PureComponent {
   state = {}
 
+  getWindow() {
+    const { externalWindow } = this.props;
+
+    return externalWindow || window;
+  }
+
+  getDocument() {
+    return this.getWindow().document;
+  }
+
   componentDidMount() {
     const options = passiveSupported ? { passive: false } : false;
 
-    document.addEventListener('mousemove', this.onDocMouseTouchMove, options);
-    document.addEventListener('touchmove', this.onDocMouseTouchMove, options);
+    this.getDocument().addEventListener('mousemove', this.onDocMouseTouchMove, options);
+    this.getDocument().addEventListener('touchmove', this.onDocMouseTouchMove, options);
 
-    document.addEventListener('mouseup', this.onDocMouseTouchEnd, options);
-    document.addEventListener('touchend', this.onDocMouseTouchEnd, options);
-    document.addEventListener('touchcancel', this.onDocMouseTouchEnd, options);
+    this.getDocument().addEventListener('mouseup', this.onDocMouseTouchEnd, options);
+    this.getDocument().addEventListener('touchend', this.onDocMouseTouchEnd, options);
+    this.getDocument().addEventListener('touchcancel', this.onDocMouseTouchEnd, options);
 
     if (this.imageRef.complete || this.imageRef.readyState) {
       if (this.imageRef.naturalWidth === 0) {
@@ -207,12 +218,12 @@ class ReactCrop extends PureComponent {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousemove', this.onDocMouseTouchMove);
-    document.removeEventListener('touchmove', this.onDocMouseTouchMove);
+    this.getDocument().removeEventListener('mousemove', this.onDocMouseTouchMove);
+    this.getDocument().removeEventListener('touchmove', this.onDocMouseTouchMove);
 
-    document.removeEventListener('mouseup', this.onDocMouseTouchEnd);
-    document.removeEventListener('touchend', this.onDocMouseTouchEnd);
-    document.removeEventListener('touchcancel', this.onDocMouseTouchEnd);
+    this.getDocument().removeEventListener('mouseup', this.onDocMouseTouchEnd);
+    this.getDocument().removeEventListener('touchend', this.onDocMouseTouchEnd);
+    this.getDocument().removeEventListener('touchcancel', this.onDocMouseTouchEnd);
   }
 
   onCropMouseTouchDown = (e) => {
@@ -788,6 +799,7 @@ ReactCrop.propTypes = {
   onDragEnd: PropTypes.func,
   src: PropTypes.string.isRequired,
   style: PropTypes.shape({}),
+  externalWindow: PropTypes.object,
 };
 
 ReactCrop.defaultProps = {


### PR DESCRIPTION
Pass external window thru props. The use case is for React Portals. When the portal is used outside main document the events are not bind properly. I'm requesting this aditional prop proposal without any braking change.