### PR TITLE
Fixing croping area

### DIFF
--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -442,11 +442,21 @@ class ReactCrop extends PureComponent {
 
   getCropStyle() {
     const { crop } = this.props;
+    const coord = getPixelCrop(this.imageRef, crop);
+    if (this.imageRef.width < this.imageRef.naturalWidth
+       && this.imageRef.height < this.imageRef.naturalHeight) {
+      return {
+        top: `${crop.y}%`,
+        left: `${crop.x}%`,
+        width: `${crop.width}%`,
+        height: `${crop.height}%`,
+      };
+    }
     return {
-      top: `${crop.y}%`,
-      left: `${crop.x}%`,
-      width: `${crop.width}%`,
-      height: `${crop.height}%`,
+      top: coord.y,
+      left: coord.x,
+      width: coord.width,
+      height: coord.height,
     };
   }
 


### PR DESCRIPTION
When we pass the following parameters to jsx component `<ReactCrop>`:
- `imageStyle={{maxWidth: 'unset', maxHeight: 'unset' }}`;
- `style={{ width: 700, height: 600, overflow: 'auto' }}`  - (it is variable, the main thing is to have smaller sizes of the original image);

the excision area is incorrect.(DOM element with class="ReactCrop__crop-selection"). For such cases, I added a check of the comparison between the original width of an image in pixels(.naturalWidth) and the width of the image, in pixels(.width)