### PR TITLE
Add support for custom render components

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,23 @@ Allows setting the crossorigin attribute on the image.
 
 Render a custom element in crop selection.
 
+#### onComponentRendered (optional)
+
+If passing in a custom component instead of an image source, this function will be called instead of `onImageLoaded`
+
+#### renderComponent (optional)
+
+Render a custom HTML element in place of an image. Useful if you want to support videos:
+
+```js
+  const renderComponent = (<video autoPlay loop><source src={this.state.src} type='video/mp4'/></video>);
+  <ReactCrop
+    src={this.state.src}
+    onChange={this.onCropChange}
+    renderComponent={renderComponent}
+  />
+```
+
 ## FAQ
 
 ### What about showing the crop on the client?

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -532,46 +532,16 @@ class ReactCrop extends PureComponent {
     };
   }
 
-  getMinWidthAndHeight() {
-    const { minWidth, minHeight } = this.props;
-    let adjustedMinWidth = minWidth;
-    let adjustedMinHeight = minHeight;
-
-    if (this.state.isPercentCrop) {
-      const { width, height } = this.imageRef;
-      adjustedMinWidth = (minWidth / 100) * width;
-      adjustedMinHeight = (minHeight / 100) * height;
-    }
-    
-    return {
-      minWidth: adjustedMinWidth,
-      minHeight: adjustedMinHeight,
-    }
-  }
-
-  getMaxWidthAndHeight() {
-    const { maxWidth, maxHeight } = this.props;
-    let adjustedMaxWidth = maxWidth;
-    let adjustedMaxHeight = maxHeight;
-
-    if (this.state.isPercentCrop) {
-      const { width, height } = this.imageRef;
-      adjustedMaxWidth = (maxWidth / 100) * width;
-      adjustedMaxHeight = (maxHeight / 100) * height;
-    }
-    
-    return {
-      maxWidth: adjustedMaxWidth,
-      maxHeight: adjustedMaxHeight,
-    }
-  }
-
   getNewSize() {
-    const { crop } = this.props;
+    const {
+      crop,	
+      minWidth,	
+      maxWidth,	
+      minHeight,	
+      maxHeight,	
+    } = this.props;      
     const { evData } = this;
     const { width, height } = this.getImageDimensions();
-    const { minWidth, minHeight } = this.getMinWidthAndHeight();
-    const { maxWidth, maxHeight } = this.getMaxWidthAndHeight();
 
     // New width.
     let newWidth = evData.cropStartWidth + evData.xDiff;

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -222,9 +222,19 @@ class ReactCrop extends PureComponent {
     }
   }
 
+  getImageDimensions() {
+    if (this.props.renderComponent) {
+      return {
+        width: this.imageRef.offsetWidth,
+        height: this.imageRef.offsetHeight,
+      }
+    }
+    return this.imageRef;
+  }
+
   onCropMouseTouchDown = (e) => {
     const { crop, disabled } = this.props;
-    const { width, height } = this.imageRef;
+    const { width, height } = this.getImageDimensions();
     const pixelCrop = convertToPixelCrop(crop, width, height);
 
     if (disabled) {
@@ -277,9 +287,10 @@ class ReactCrop extends PureComponent {
       locked,
       keepSelection,
       onChange,
+      renderComponent
     } = this.props;
 
-    if (e.target !== this.imageRef) {
+    if ((!renderComponent && e.target !== this.imageRef) || (renderComponent && !this.imageRef.childNodes[0].contains(e.target))) {
       return;
     }
 
@@ -325,10 +336,11 @@ class ReactCrop extends PureComponent {
     };
 
     this.mouseDownOnCrop = true;
+    const { width, height } = this.getImageDimensions();
 
     onChange(
-      convertToPixelCrop(nextCrop, this.imageRef.width, this.imageRef.height),
-      convertToPercentCrop(nextCrop, this.imageRef.width, this.imageRef.height),
+      convertToPixelCrop(nextCrop, width, height),
+      convertToPercentCrop(nextCrop, width, height),
     );
 
     this.setState({ cropIsActive: true, newCropIsBeingDrawn: true });
@@ -376,7 +388,7 @@ class ReactCrop extends PureComponent {
     }
 
     if (nextCrop !== crop) {
-      const { width, height } = this.imageRef;
+      const { width, height } = this.getImageDimensions();
 
       onChange(
         convertToPixelCrop(nextCrop, width, height),
@@ -422,7 +434,7 @@ class ReactCrop extends PureComponent {
 
     if (nudged) {
       e.preventDefault(); // Stop drag selection.
-      const { width, height } = this.imageRef;
+      const { width, height } = this.getImageDimensions();
 
       nextCrop.x = clamp(nextCrop.x, 0, width - nextCrop.width);
       nextCrop.y = clamp(nextCrop.y, 0, height - nextCrop.height);
@@ -450,11 +462,12 @@ class ReactCrop extends PureComponent {
     if (this.mouseDownOnCrop) {
       this.mouseDownOnCrop = false;
       this.dragStarted = false;
+      const { width, height } = this.getImageDimensions();
 
       onDragEnd(e);
       onComplete(
-        convertToPixelCrop(crop, this.imageRef.width, this.imageRef.height),
-        convertToPercentCrop(crop, this.imageRef.width, this.imageRef.height),
+        convertToPixelCrop(crop, width, height),
+        convertToPercentCrop(crop, width, height),
       );
 
       this.setState({ cropIsActive: false, newCropIsBeingDrawn: false });
@@ -466,18 +479,22 @@ class ReactCrop extends PureComponent {
       onComplete,
       onChange,
       onImageLoaded,
+      onComponentRendered,
+      renderComponent,
     } = this.props;
 
     const crop = this.makeNewCrop();
-    const resolvedCrop = resolveCrop(crop, image.width, image.height);
+    const { width, height } = this.getImageDimensions();
+    const resolvedCrop = resolveCrop(crop, width, height);
 
-    // Return false from onImageLoaded if you set the crop with setState in there as otherwise
+    // Return false from onImageLoaded or onComponentRendered if you set the crop with setState in there as otherwise
     // the subsequent onChange + onComplete will not have your updated crop.
-    const res = onImageLoaded(image);
+    const res = renderComponent ? onComponentRendered() : onImageLoaded(image);
 
     if (res !== false) {
-      const pixelCrop = convertToPixelCrop(resolvedCrop, image.width, image.height);
-      const percentCrop = convertToPercentCrop(resolvedCrop, image.width, image.height);
+      const { width, height } = this.getImageDimensions();
+      const pixelCrop = convertToPixelCrop(resolvedCrop, width, height);
+      const percentCrop = convertToPercentCrop(resolvedCrop, width, height);
       onChange(pixelCrop, percentCrop);
       onComplete(pixelCrop, percentCrop);
     }
@@ -524,7 +541,7 @@ class ReactCrop extends PureComponent {
       maxHeight,
     } = this.props;
     const { evData } = this;
-    const { width, height } = this.imageRef;
+    const { width, height } = this.getImageDimensions();
 
     // New width.
     let newWidth = evData.cropStartWidth + evData.xDiff;
@@ -564,9 +581,10 @@ class ReactCrop extends PureComponent {
   dragCrop() {
     const nextCrop = this.makeNewCrop();
     const { evData } = this;
+    const { width, height } = this.getImageDimensions();
 
-    nextCrop.x = clamp(evData.cropStartX + evData.xDiff, 0, this.imageRef.width - nextCrop.width);
-    nextCrop.y = clamp(evData.cropStartY + evData.yDiff, 0, this.imageRef.height - nextCrop.height);
+    nextCrop.x = clamp(evData.cropStartX + evData.xDiff, 0, width - nextCrop.width);
+    nextCrop.y = clamp(evData.cropStartY + evData.yDiff, 0, height - nextCrop.height);
 
     return nextCrop;
   }
@@ -610,6 +628,7 @@ class ReactCrop extends PureComponent {
       }
     }
 
+    const { width, height } = this.getImageDimensions();
     const containedCrop = containCrop(this.props.crop, {
       unit: nextCrop.unit,
       x: newX,
@@ -617,7 +636,7 @@ class ReactCrop extends PureComponent {
       width: newSize.width,
       height: newSize.height,
       aspect: nextCrop.aspect,
-    }, this.imageRef.width, this.imageRef.height);
+    }, width, height);
 
     // Apply x/y/width/height changes depending on ordinate (fixed aspect always applies both).
     if (nextCrop.aspect || ReactCrop.xyOrds.indexOf(ord) > -1) {
@@ -694,7 +713,7 @@ class ReactCrop extends PureComponent {
 
   makeNewCrop(unit = 'px') {
     const crop = { ...ReactCrop.defaultCrop, ...this.props.crop };
-    const { width, height } = this.imageRef;
+    const { width, height } = this.getImageDimensions();
 
     return unit === 'px' ?
       convertToPixelCrop(crop, width, height) :
@@ -734,6 +753,7 @@ class ReactCrop extends PureComponent {
       src,
       style,
       imageStyle,
+      renderComponent,
     } = this.props;
 
     const { cropIsActive, newCropIsBeingDrawn } = this.state;
@@ -749,6 +769,34 @@ class ReactCrop extends PureComponent {
       'ReactCrop--crop-invisible': crop && cropIsActive && (!crop.width || !crop.height),
     });
 
+    // In order to call onImageLoad once the renderComponent has been loaded, we use a dummy image with width
+    // and height set to 0. In order to prevent browser warnings, we pass in a base 64 src, which is 1 x 1
+    // transparent gif. Details of this implementation can be found here: https://stackoverflow.com/a/27754238
+    const component = renderComponent 
+    ? (
+      <div
+        ref={(n) => { this.imageRef = n; }}
+        className="ReactCrop__image"
+        style={imageStyle}
+        onError={onImageError}
+      >
+        {renderComponent}
+        <img src='data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==' width='0' height='0' onLoad={e => { this.onImageLoad(e.target)}}/>
+      </div>
+    )
+    : (
+      <img
+        ref={(n) => { this.imageRef = n; }}
+        crossOrigin={crossorigin}
+        className="ReactCrop__image"
+        style={imageStyle}
+        src={src}
+        onLoad={e => this.onImageLoad(e.target)}
+        onError={onImageError}
+        alt={imageAlt}
+      />
+    );
+
     return (
       <div
         ref={(n) => { this.componentRef = n; }}
@@ -760,16 +808,7 @@ class ReactCrop extends PureComponent {
         tabIndex={1}
         onKeyDown={this.onComponentKeyDown}
       >
-        <img
-          ref={(n) => { this.imageRef = n; }}
-          crossOrigin={crossorigin}
-          className="ReactCrop__image"
-          style={imageStyle}
-          src={src}
-          onLoad={e => this.onImageLoad(e.target)}
-          onError={onImageError}
-          alt={imageAlt}
-        />
+        {component}
         {children}
         {cropSelection}
       </div>
@@ -828,9 +867,11 @@ ReactCrop.propTypes = {
   onImageLoaded: PropTypes.func,
   onDragStart: PropTypes.func,
   onDragEnd: PropTypes.func,
+  onComponentRendered: PropTypes.func,
   src: PropTypes.string.isRequired,
   style: PropTypes.shape({}),
   renderSelectionAddon: PropTypes.func,
+  renderComponent: PropTypes.element,
 };
 
 ReactCrop.defaultProps = {
@@ -850,10 +891,12 @@ ReactCrop.defaultProps = {
   onImageLoaded: () => {},
   onDragStart: () => {},
   onDragEnd: () => {},
+  onComponentRendered: () => {},
   children: undefined,
   style: undefined,
   imageStyle: undefined,
   renderSelectionAddon: undefined,
+  renderComponent: undefined,
 };
 
 export {

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -532,16 +532,46 @@ class ReactCrop extends PureComponent {
     };
   }
 
+  getMinWidthAndHeight() {
+    const { minWidth, minHeight } = this.props;
+    let adjustedMinWidth = minWidth;
+    let adjustedMinHeight = minHeight;
+
+    if (this.state.isPercentCrop) {
+      const { width, height } = this.imageRef;
+      adjustedMinWidth = (minWidth / 100) * width;
+      adjustedMinHeight = (minHeight / 100) * height;
+    }
+    
+    return {
+      minWidth: adjustedMinWidth,
+      minHeight: adjustedMinHeight,
+    }
+  }
+
+  getMaxWidthAndHeight() {
+    const { maxWidth, maxHeight } = this.props;
+    let adjustedMaxWidth = maxWidth;
+    let adjustedMaxHeight = maxHeight;
+
+    if (this.state.isPercentCrop) {
+      const { width, height } = this.imageRef;
+      adjustedMaxWidth = (maxWidth / 100) * width;
+      adjustedMaxHeight = (maxHeight / 100) * height;
+    }
+    
+    return {
+      maxWidth: adjustedMaxWidth,
+      maxHeight: adjustedMaxHeight,
+    }
+  }
+
   getNewSize() {
-    const {
-      crop,
-      minWidth,
-      maxWidth,
-      minHeight,
-      maxHeight,
-    } = this.props;
+    const { crop } = this.props;
     const { evData } = this;
     const { width, height } = this.getImageDimensions();
+    const { minWidth, minHeight } = this.getMinWidthAndHeight();
+    const { maxWidth, maxHeight } = this.getMaxWidthAndHeight();
 
     // New width.
     let newWidth = evData.cropStartWidth + evData.xDiff;


### PR DESCRIPTION
This adds support for the option to pass in a `renderComponent`, which will be rendered instead of an `<img>` tag. This means the cropper should in theory work with any HTML component passed in. The main use case envisioned is to support cropping videos.

[Live Demo](https://codesandbox.io/s/react-image-crop-custom-component-yeqgq)

![Jun-19-2019 15-00-12](https://user-images.githubusercontent.com/10169700/59804368-fdaf6b80-92a2-11e9-9a4b-f12965b51ea4.gif)
