### PR TITLE
Add tabindex to crop selection

### DIFF
--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -715,7 +715,7 @@ class ReactCrop extends PureComponent {
         className="ReactCrop__crop-selection"
         onMouseDown={this.onCropMouseTouchDown}
         onTouchStart={this.onCropMouseTouchDown}
-        role="presentation"
+        tabIndex="0"
       >
         {!disabled && !locked && (
           <div className="ReactCrop__drag-elements">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image-crop",
-  "version": "8.3.1",
+  "version": "8.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This removes the role of presentation from the crop selection and replaces it with tabindex of 0.  This will allow the crop area to be accessed via the keyboard.  The removal of `role="presentation"` is per the ARIA spec here: https://www.w3.org/TR/wai-aria-practices/#presentation_role_ignored.

The video I attached shows how the cropper acts the same when interacting with the mouse but now it has the additional benefit of being able to be accessed by tabbing.  There isn't any `aria-` tags on the crop selection which I believe to be fine as a library like this probably doesn't need to account for users with vision impairment as I'm guessing they would be much less likely to be editing images.  Rather, this accounts for users who are not vision impaired but still use the keyboard for interacting with their computer. 

The package-lock.json version got updated when I ran `npm install` as it looks like they were out of sync.  I can revert that if you would like.

Related to #314 

cc: @avo