### PR TITLE
Improve nudging

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,6 @@ const onLoad = useCallback(img => {
 
 ## Contributing / Developing
 
-To develop run `npm start`, this will recompile your JS and SCSS on changes.
+To develop run `yarn start`, this will recompile your JS and SCSS on changes.
 
 You can test your changes by opening `test/index.html` in a browser (you don't need to be running a server).

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -414,7 +414,12 @@ class ReactCrop extends PureComponent {
     }
 
     const nextCrop = this.makeNewCrop();
-    const nudgeStep = e.shiftKey ? ReactCrop.nudgeStepLarge : ReactCrop.nudgeStep;
+    const ctrlCmdPressed = navigator.platform.match('Mac') ? e.metaKey : e.ctrlKey;
+    const nudgeStep = ctrlCmdPressed
+      ? ReactCrop.nudgeStepLarge
+      : e.shiftKey
+      ? ReactCrop.nudgeStepMedium
+      : ReactCrop.nudgeStep;
 
     if (keyCode === 'ArrowLeft') {
       nextCrop.x -= nudgeStep;
@@ -830,8 +835,9 @@ ReactCrop.xOrds = ['e', 'w'];
 ReactCrop.yOrds = ['n', 's'];
 ReactCrop.xyOrds = ['nw', 'ne', 'se', 'sw'];
 
-ReactCrop.nudgeStep = 0.2;
-ReactCrop.nudgeStepLarge = 2;
+ReactCrop.nudgeStep = 1;
+ReactCrop.nudgeStepMedium = 10;
+ReactCrop.nudgeStepLarge = 100;
 
 ReactCrop.defaultCrop = {
   x: 0,

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -690,7 +690,6 @@ class ReactCrop extends PureComponent {
         className="ReactCrop__crop-selection"
         onMouseDown={this.onCropMouseTouchDown}
         onTouchStart={this.onCropMouseTouchDown}
-        tabIndex="0"
       >
         {!disabled && !locked && (
           <div className="ReactCrop__drag-elements">


### PR DESCRIPTION
Fixes #314 

This PR address three accessibility issues:

1. Removes the `tabIndex` on the crop selection div in favor of the `tabIndex` on the root div.  Apps can style the focus border as needed to provide a visual indicator that the cropper is selected.
1. Increases the nudge step to 1px and the large nudge step to 10px to match better with other crop experiences.
1. Renames `nudgeStepLarge` to `nudgeStepMedium` to allow adding a new variable for nudging with the cmd/ctrl key.  When using the cmd/ctrl key nudge it will move the crop selection by 100px.  This handles the keybindings based on the current platform so if mac is detected the cmd key will be used otherwise the ctrl key will be used.