### PR TITLE
Do not render selection add-on while crop area doesn't get displayed

### DIFF
--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -713,7 +713,7 @@ class ReactCrop extends PureComponent {
             <div className="ReactCrop__drag-handle ord-w" data-ord="w" />
           </div>
         )}
-        {renderSelectionAddon && !!crop.width && (
+        {renderSelectionAddon && isCropValid(crop) && (
           <div className="ReactCrop__selection-addon" onMouseDown={e => e.stopPropagation()}>
             {renderSelectionAddon(this.state)}
           </div>

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -685,7 +685,7 @@ class ReactCrop extends PureComponent {
   }
 
   createCropSelection() {
-    const { disabled, locked, renderSelectionAddon, ruleOfThirds } = this.props;
+    const { disabled, locked, renderSelectionAddon, ruleOfThirds, crop } = this.props;
     const style = this.getCropStyle();
 
     return (
@@ -713,7 +713,7 @@ class ReactCrop extends PureComponent {
             <div className="ReactCrop__drag-handle ord-w" data-ord="w" />
           </div>
         )}
-        {renderSelectionAddon && (
+        {renderSelectionAddon && !!crop.width && (
           <div className="ReactCrop__selection-addon" onMouseDown={e => e.stopPropagation()}>
             {renderSelectionAddon(this.state)}
           </div>


### PR DESCRIPTION
This is a selection add-on in case of having a crop area.

<img width="311" alt="Screen Shot 2020-09-07 at 17 58 54" src="https://user-images.githubusercontent.com/13638569/92370545-65b2d180-f135-11ea-9e3d-ab507dcdc693.png">

In case the crop area does not exist, a selection add-on is still displayed.

<img width="283" alt="Screen Shot 2020-09-07 at 17 59 04" src="https://user-images.githubusercontent.com/13638569/92370554-68adc200-f135-11ea-8829-6f9d1f60e3e1.png">
