### PR TITLE
Allow nuding in multiple directions

### DIFF
--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -195,6 +195,8 @@ class ReactCrop extends PureComponent {
 
   state = {};
 
+  keysDown = new Set();
+
   componentDidMount() {
     if (this.document.addEventListener) {
       const options = passiveSupported ? { passive: false } : false;
@@ -406,7 +408,7 @@ class ReactCrop extends PureComponent {
       return;
     }
 
-    const keyCode = e.key;
+    this.keysDown.add(e.key);
     let nudged = false;
 
     if (!isCropValid(crop)) {
@@ -421,16 +423,22 @@ class ReactCrop extends PureComponent {
       ? ReactCrop.nudgeStepMedium
       : ReactCrop.nudgeStep;
 
-    if (keyCode === 'ArrowLeft') {
+    if (this.keysDown.has('ArrowLeft')) {
       nextCrop.x -= nudgeStep;
       nudged = true;
-    } else if (keyCode === 'ArrowRight') {
+    }
+
+    if (this.keysDown.has('ArrowRight')) {
       nextCrop.x += nudgeStep;
       nudged = true;
-    } else if (keyCode === 'ArrowUp') {
+    }
+
+    if (this.keysDown.has('ArrowUp')) {
       nextCrop.y -= nudgeStep;
       nudged = true;
-    } else if (keyCode === 'ArrowDown') {
+    }
+
+    if (this.keysDown.has('ArrowDown')) {
       nextCrop.y += nudgeStep;
       nudged = true;
     }
@@ -448,6 +456,10 @@ class ReactCrop extends PureComponent {
       onChange(pixelCrop, percentCrop);
       onComplete(pixelCrop, percentCrop);
     }
+  };
+
+  onComponentKeyUp = e => {
+    this.keysDown.delete(e.key);
   };
 
   onDocMouseTouchEnd = e => {
@@ -805,6 +817,7 @@ class ReactCrop extends PureComponent {
         onMouseDown={this.onComponentMouseTouchDown}
         tabIndex="0"
         onKeyDown={this.onComponentKeyDown}
+        onKeyUp={this.onComponentKeyUp}
       >
         <div
           ref={n => {


### PR DESCRIPTION
Currently, if you hold down multiple keys when nudging, the cropper will pick the most recently pressed key and use it for the nudge direction.  This can make it confusing when attempting to crop towards a corner.  This PR adds a new variable to the class called `keysDown` (essentially a ref since it doesn't need to be state) which tracks the keys that are currently down.  Then, when keydown is fired we can calculate the nudge based on all the keys which are down.

The main question I have for you about this PR is my usage of `Set` which I'm not sure if that is okay based on the browser support of this library.  The mdn docs would seem to indicate that even IE11 supports the `add`, `has`, and `delete` methods which is all that I needed to use for this PR.  I assume then it's okay to use?  If so, I'll need to fix the ESLint warning about Set not being defined.