### PR TITLE
Add support for React 17 and fix infinite updates within modals

### DIFF
--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -508,7 +508,9 @@ class ReactCrop extends PureComponent {
     onComplete(pixelCrop, percentCrop);
   };
 
-  onImageLoad(image) {
+  onImageLoad = event => {
+    const { target: image } = event;
+
     const { onComplete, onChange, onImageLoaded } = this.props;
 
     // Return false from onImageLoaded if you set the crop with setState in there as otherwise
@@ -520,7 +522,7 @@ class ReactCrop extends PureComponent {
       onChange(pixelCrop, percentCrop);
       onComplete(pixelCrop, percentCrop);
     }
-  }
+  };
 
   get mediaDimensions() {
     const { clientWidth, clientHeight } = this.mediaWrapperRef;
@@ -708,7 +710,7 @@ class ReactCrop extends PureComponent {
 
     return (
       <div
-        ref={r => (this.cropSelectRef = r)}
+        ref={this.bindCropSelectionRef}
         style={style}
         className="ReactCrop__crop-selection"
         onMouseDown={this.onCropMouseTouchDown}
@@ -780,6 +782,22 @@ class ReactCrop extends PureComponent {
     evData.inversedYOrd = swapYOrd ? inverseOrd(evData.ord) : false;
   }
 
+  bindComponentRef = ref => {
+    this.componentRef = ref;
+  };
+
+  bindMediaWrapperRef = ref => {
+    this.mediaWrapperRef = ref;
+  };
+
+  bindImageRef = ref => {
+    this.imageRef = ref;
+  };
+
+  bindCropSelectionRef = ref => {
+    this.cropSelectRef = ref;
+  };
+
   render() {
     const {
       children,
@@ -814,9 +832,7 @@ class ReactCrop extends PureComponent {
 
     return (
       <div
-        ref={n => {
-          this.componentRef = n;
-        }}
+        ref={this.bindComponentRef}
         className={componentClasses}
         style={style}
         onTouchStart={this.onComponentMouseTouchDown}
@@ -825,19 +841,15 @@ class ReactCrop extends PureComponent {
         onKeyDown={this.onComponentKeyDown}
         onKeyUp={this.onComponentKeyUp}
       >
-        <div
-          ref={n => {
-            this.mediaWrapperRef = n;
-          }}
-        >
+        <div ref={this.bindMediaWrapperRef}>
           {renderComponent || (
             <img
-              ref={r => (this.imageRef = r)}
+              ref={this.bindImageRef}
               crossOrigin={crossorigin}
               className="ReactCrop__image"
               style={imageStyle}
               src={src}
-              onLoad={e => this.onImageLoad(e.target)}
+              onLoad={this.onImageLoad}
               onError={onImageError}
               alt={imageAlt}
             />

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -424,8 +424,8 @@ class ReactCrop extends PureComponent {
     const nudgeStep = ctrlCmdPressed
       ? ReactCrop.nudgeStepLarge
       : e.shiftKey
-        ? ReactCrop.nudgeStepMedium
-        : ReactCrop.nudgeStep;
+      ? ReactCrop.nudgeStepMedium
+      : ReactCrop.nudgeStep;
 
     if (this.keysDown.has('ArrowLeft')) {
       nextCrop.x -= nudgeStep;
@@ -914,11 +914,11 @@ ReactCrop.defaultProps = {
   minWidth: 0,
   minHeight: 0,
   keepSelection: false,
-  onComplete: () => { },
-  onImageError: () => { },
-  onImageLoaded: () => { },
-  onDragStart: () => { },
-  onDragEnd: () => { },
+  onComplete: () => {},
+  onImageError: () => {},
+  onImageLoaded: () => {},
+  onDragStart: () => {},
+  onDragEnd: () => {},
   children: undefined,
   style: undefined,
   renderComponent: undefined,

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -225,6 +225,8 @@ class ReactCrop extends PureComponent {
     this.document.addEventListener('mouseup', this.onDocMouseTouchEnd, DOC_MOVE_EVENT_LISTENER_OPTIONS);
     this.document.addEventListener('touchend', this.onDocMouseTouchEnd, DOC_MOVE_EVENT_LISTENER_OPTIONS);
     this.document.addEventListener('touchcancel', this.onDocMouseTouchEnd, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+
+    this.docMoveBound = true;
   }
 
   unbindDocMove() {

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -171,6 +171,8 @@ function containCrop(prevCrop, crop, imageWidth, imageHeight) {
   return contained;
 }
 
+const DOC_MOVE_EVENT_LISTENER_OPTIONS = { capture: true, passive: false };
+
 class ReactCrop extends PureComponent {
   window = typeof window !== 'undefined' ? window : {};
 
@@ -213,21 +215,31 @@ class ReactCrop extends PureComponent {
   }
 
   bindDocMove() {
-    this.document.addEventListener('mousemove', this.onDocMouseTouchMove);
-    this.document.addEventListener('touchmove', this.onDocMouseTouchMove, { passing: false });
+    if (this.docMoveBound) {
+      return;
+    }
 
-    this.document.addEventListener('mouseup', this.onDocMouseTouchEnd);
-    this.document.addEventListener('touchend', this.onDocMouseTouchEnd, { passing: false });
-    this.document.addEventListener('touchcancel', this.onDocMouseTouchEnd, { passing: false });
+    this.document.addEventListener('mousemove', this.onDocMouseTouchMove, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+    this.document.addEventListener('touchmove', this.onDocMouseTouchMove, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+
+    this.document.addEventListener('mouseup', this.onDocMouseTouchEnd, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+    this.document.addEventListener('touchend', this.onDocMouseTouchEnd, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+    this.document.addEventListener('touchcancel', this.onDocMouseTouchEnd, DOC_MOVE_EVENT_LISTENER_OPTIONS);
   }
 
   unbindDocMove() {
-    this.document.removeEventListener('mousemove', this.onDocMouseTouchMove);
-    this.document.removeEventListener('touchmove', this.onDocMouseTouchMove);
+    if (!this.docMoveBound) {
+      return;
+    }
 
-    this.document.removeEventListener('mouseup', this.onDocMouseTouchEnd);
-    this.document.removeEventListener('touchend', this.onDocMouseTouchEnd);
-    this.document.removeEventListener('touchcancel', this.onDocMouseTouchEnd);
+    this.document.removeEventListener('mousemove', this.onDocMouseTouchMove, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+    this.document.removeEventListener('touchmove', this.onDocMouseTouchMove, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+
+    this.document.removeEventListener('mouseup', this.onDocMouseTouchEnd, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+    this.document.removeEventListener('touchend', this.onDocMouseTouchEnd, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+    this.document.removeEventListener('touchcancel', this.onDocMouseTouchEnd, DOC_MOVE_EVENT_LISTENER_OPTIONS);
+
+    this.docMoveBound = false;
   }
 
   onCropMouseTouchDown = e => {
@@ -238,6 +250,7 @@ class ReactCrop extends PureComponent {
     if (disabled) {
       return;
     }
+
     e.preventDefault(); // Stop drag selection.
 
     // Bind to doc to follow movements outside of element.

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.21.5",
     "node-sass": "^5.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^16.13.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "style-loader": "^2.0.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12"
   },
   "peerDependencies": {
-    "react": ">=16.13.1"
+    "react": ">=16.13.1 || ^17.0.0"
   },
   "dependencies": {
     "clsx": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "https://github.com/DominicTobias/react-image-crop",
   "main": "dist/ReactCrop.min.js",
   "style": "dist/ReactCrop.css",
+  "files": [
+    "dist"
+  ],
   "browserslist": "last 3 versions, not IE > 0",
   "scripts": {
     "start": "webpack --progress --colors --watch --config test/webpack.config.js & npm run sass-watch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4505,7 +4505,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -4606,25 +4606,24 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-react-dom@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.2"
 
 react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
-  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -4945,10 +4944,10 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
I've switched `docMove` event handler modes to use the event capturing phase so they are not interrupted by other components that may prevent the `unbindDocMove` from being called (https://reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues), which causes an infinite update loop. Also, they are made non-passive by default (was the `passing: false` (passive?) a typo anyway?).

Moreover, when React gets `ref` as an arrow function, it will see it changes at each render call and it will dispatch two calls one with `null`, followed by a proper ref value after each render. By using static binders, the issue is no longer present as the reference to `this.bindX` is constant.

The npm package for the current version also includes files that were not intended for being published, like test files, source, etc. By including only files in the dist directory, the package size drops from 1.28 MB to just 134 kB.

You can compare the new behavior with the current one with the fork at https://www.npmjs.com/package/@sandstreamdev/react-image-crop

Fixes #404 