### PR TITLE
Feature: Add scale prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ Show the crop area as a circle. If your aspect is not 1 (a square) then the circ
 
 If a parent element is zoomed or scaled, you can pass in the scale factor in order to correct the cropping bounds. Defaults to `1`.
 
+#### rotate (optional)
+
+If a parent element is rotated, you can pass in the rotation in degrees in order to correct the cropping bounds. Defaults to `0`, range is from `-180` to `180`.
+
 ## FAQ
 
 ### What about showing the crop on the client?

--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ Show [rule of thirds](https://en.wikipedia.org/wiki/Rule_of_thirds) lines in the
 
 Show the crop area as a circle. If your aspect is not 1 (a square) then the circle will be warped into an oval shape. Defaults to `false`.
 
+#### scale (optional)
+
+If a parent element is zoomed or scaled, you can pass in the scale factor in order to correct the cropping bounds. Defaults to `1`.
+
 ## FAQ
 
 ### What about showing the crop on the client?

--- a/README.md
+++ b/README.md
@@ -272,10 +272,6 @@ Show the crop area as a circle. If your aspect is not 1 (a square) then the circ
 
 If a parent element is zoomed or scaled, you can pass in the scale factor in order to correct the cropping bounds. Defaults to `1`.
 
-#### rotate (optional)
-
-If a parent element is rotated, you can pass in the rotation in degrees in order to correct the cropping bounds. Defaults to `0`, range is from `-180` to `180`.
-
 ## FAQ
 
 ### What about showing the crop on the client?

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -265,7 +265,7 @@ class ReactCrop extends PureComponent {
   };
 
   onComponentPointerDown = e => {
-    const { crop, disabled, locked, keepSelection, onChange, scale, rotate } = this.props;
+    const { crop, disabled, locked, keepSelection, onChange, scale } = this.props;
 
     const componentEl = this.mediaWrapperRef.firstChild;
 
@@ -287,25 +287,8 @@ class ReactCrop extends PureComponent {
 
     const rect = this.mediaWrapperRef.getBoundingClientRect();
 
-    let x;
-    let y;
-    let scaledX = (e.clientX - rect.left) / scale;
-    let scaledY = (e.clientY - rect.top) / scale;
-    let degrees = rotate;
-    let radians = Math.abs((degrees * Math.PI) / 180.0);
-    if ((degrees > -45 && degrees <= 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
-      // Top and Bottom
-      x = scaledX * Math.cos(radians);
-      y = scaledY * Math.cos(radians);
-    } else if (degrees > 45 && degrees <= 135) {
-      // Left
-      x = scaledY * Math.sin(radians);
-      y = scaledX * Math.sin(radians) * -1;
-    } else if (degrees > -135 && degrees <= -45) {
-      // Right
-      x = scaledY * Math.sin(radians) * -1;
-      y = scaledX * Math.sin(radians);
-    }
+    let x = (e.clientX - rect.left) / scale;
+    let y = (e.clientY - rect.top) / scale;
 
     const nextCrop = {
       unit: 'px',
@@ -343,7 +326,7 @@ class ReactCrop extends PureComponent {
   };
 
   onDocPointerMove = e => {
-    const { crop, disabled, onChange, onDragStart, scale, rotate } = this.props;
+    const { crop, disabled, onChange, onDragStart, scale } = this.props;
 
     if (disabled) {
       return;
@@ -362,23 +345,8 @@ class ReactCrop extends PureComponent {
 
     const { evData } = this;
 
-    let scaledX = (e.clientX - evData.clientStartX) / scale;
-    let scaledY = (e.clientY - evData.clientStartY) / scale;
-    let degrees = rotate;
-    let radians = Math.abs((degrees * Math.PI) / 180.0);
-    if ((degrees > -45 && degrees <= 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
-      // Top and Bottom
-      evData.xDiff = scaledX * Math.cos(radians);
-      evData.yDiff = scaledY * Math.cos(radians);
-    } else if (degrees > 45 && degrees <= 135) {
-      // Left
-      evData.xDiff = scaledY * Math.sin(radians);
-      evData.yDiff = scaledX * Math.sin(radians) * -1;
-    } else if (degrees > -135 && degrees <= -45) {
-      // Right
-      evData.xDiff = scaledY * Math.sin(radians) * -1;
-      evData.yDiff = scaledX * Math.sin(radians);
-    }
+    evData.xDiff = (e.clientX - evData.clientStartX) / scale;
+    evData.yDiff = (e.clientY - evData.clientStartY) / scale;
 
     let nextCrop;
 
@@ -661,52 +629,8 @@ class ReactCrop extends PureComponent {
     return nextCrop;
   }
 
-  getRotatedCursor(handle, degrees) {
-    if ((degrees > -45 && degrees <= 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
-      // Top and Bottom
-      switch(handle) {
-        case "nw":
-          return {cursor: "nw-resize"};
-        case "n":
-          return {cursor: "n-resize"};
-        case "ne":
-          return {cursor: "ne-resize"};
-        case "e":
-          return {cursor: "e-resize"};
-        case "se":
-          return {cursor: "se-resize"};
-        case "s":
-          return {cursor: "s-resize"};
-        case "sw":
-          return {cursor: "sw-resize"};
-        case "w":
-          return {cursor: "w-resize"};
-      }
-    } else if ((degrees > -135 && degrees <= -45) || (degrees > 45 && degrees <= 135)) {
-      // Left and Right
-      switch(handle) {
-        case "nw":
-          return {cursor: "ne-resize"};
-        case "n":
-          return {cursor: "w-resize"};
-        case "ne":
-          return {cursor: "nw-resize"};
-        case "e":
-          return {cursor: "s-resize"};
-        case "se":
-          return {cursor: "sw-resize"};
-        case "s":
-          return {cursor: "e-resize"};
-        case "sw":
-          return {cursor: "se-resize"};
-        case "w":
-          return {cursor: "n-resize"};
-      }
-    }
-  }
-
   createCropSelection() {
-    const { disabled, locked, renderSelectionAddon, ruleOfThirds, crop, rotate } = this.props;
+    const { disabled, locked, renderSelectionAddon, ruleOfThirds, crop } = this.props;
     const style = this.getCropStyle();
 
     return (
@@ -723,14 +647,14 @@ class ReactCrop extends PureComponent {
           <div className="ReactCrop__drag-bar ord-s" data-ord="s" />
           <div className="ReactCrop__drag-bar ord-w" data-ord="w" />
 
-          <div className="ReactCrop__drag-handle ord-nw" data-ord="nw" style={this.getRotatedCursor("nw", rotate)} />
-          <div className="ReactCrop__drag-handle ord-n" data-ord="n" style={this.getRotatedCursor("n", rotate)} />
-          <div className="ReactCrop__drag-handle ord-ne" data-ord="ne" style={this.getRotatedCursor("ne", rotate)} />
-          <div className="ReactCrop__drag-handle ord-e" data-ord="e" style={this.getRotatedCursor("e", rotate)} />
-          <div className="ReactCrop__drag-handle ord-se" data-ord="se" style={this.getRotatedCursor("se", rotate)} />
-          <div className="ReactCrop__drag-handle ord-s" data-ord="s" style={this.getRotatedCursor("s", rotate)} />
-          <div className="ReactCrop__drag-handle ord-sw" data-ord="sw" style={this.getRotatedCursor("sw", rotate)} />
-          <div className="ReactCrop__drag-handle ord-w" data-ord="w" style={this.getRotatedCursor("w", rotate)} />
+          <div className="ReactCrop__drag-handle ord-nw" data-ord="nw" />
+          <div className="ReactCrop__drag-handle ord-n" data-ord="n" />
+          <div className="ReactCrop__drag-handle ord-ne" data-ord="ne" />
+          <div className="ReactCrop__drag-handle ord-e" data-ord="e" />
+          <div className="ReactCrop__drag-handle ord-se" data-ord="se" />
+          <div className="ReactCrop__drag-handle ord-s" data-ord="s" />
+          <div className="ReactCrop__drag-handle ord-sw" data-ord="sw" />
+          <div className="ReactCrop__drag-handle ord-w" data-ord="w" />
         </div>
       )}
         {renderSelectionAddon && isCropValid(crop) && (
@@ -910,8 +834,7 @@ ReactCrop.propTypes = {
   renderComponent: PropTypes.node,
   renderSelectionAddon: PropTypes.func,
   ruleOfThirds: PropTypes.bool,
-  scale: PropTypes.number,
-  rotate: PropTypes.number
+  scale: PropTypes.number
 };
 
 ReactCrop.defaultProps = {
@@ -938,8 +861,7 @@ ReactCrop.defaultProps = {
   imageStyle: undefined,
   renderSelectionAddon: undefined,
   ruleOfThirds: false,
-  scale: 1,
-  rotate: 0
+  scale: 1
 };
 
 export { ReactCrop as default, ReactCrop as Component, makeAspectCrop, containCrop };

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -265,7 +265,7 @@ class ReactCrop extends PureComponent {
   };
 
   onComponentPointerDown = e => {
-    const { crop, disabled, locked, keepSelection, onChange, scale } = this.props;
+    const { crop, disabled, locked, keepSelection, onChange, scale, rotate } = this.props;
 
     const componentEl = this.mediaWrapperRef.firstChild;
 
@@ -286,8 +286,26 @@ class ReactCrop extends PureComponent {
     this.componentRef.focus({ preventScroll: true }); // All other browsers
 
     const rect = this.mediaWrapperRef.getBoundingClientRect();
-    const x = (e.clientX - rect.left) / scale;
-    const y = (e.clientY - rect.top) / scale;
+
+    let x;
+    let y;
+    let scaledX = (e.clientX - rect.left) / scale;
+    let scaledY = (e.clientY - rect.top) / scale;
+    let degrees = rotate;
+    let radians = Math.abs((degrees * Math.PI) / 180.0);
+    if ((degrees > -45 && degrees < 45) || ((degrees >= -180 && degrees < -135) || (degrees > 135 && degrees <= 180))) {
+      // Top and Bottom
+      x = scaledX * Math.cos(radians);
+      y = scaledY * Math.cos(radians);
+    } else if (degrees > 45 && degrees < 135) {
+      // Left
+      x = scaledY * Math.sin(radians);
+      y = scaledX * Math.sin(radians) * -1;
+    } else if (degrees > -135 && degrees < -45) {
+      // Right
+      x = scaledY * Math.sin(radians) * -1;
+      y = scaledX * Math.sin(radians);
+    }
 
     const nextCrop = {
       unit: 'px',
@@ -325,7 +343,7 @@ class ReactCrop extends PureComponent {
   };
 
   onDocPointerMove = e => {
-    const { crop, disabled, onChange, onDragStart, scale } = this.props;
+    const { crop, disabled, onChange, onDragStart, scale, rotate } = this.props;
 
     if (disabled) {
       return;
@@ -344,8 +362,23 @@ class ReactCrop extends PureComponent {
 
     const { evData } = this;
 
-    evData.xDiff = (e.clientX - evData.clientStartX) / scale;
-    evData.yDiff = (e.clientY - evData.clientStartY) / scale;
+    let scaledX = (e.clientX - evData.clientStartX) / scale;
+    let scaledY = (e.clientY - evData.clientStartY) / scale;
+    let degrees = rotate;
+    let radians = Math.abs((degrees * Math.PI) / 180.0);
+    if ((degrees > -45 && degrees < 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
+      // Top and Bottom
+      evData.xDiff = scaledX * Math.cos(radians);
+      evData.yDiff = scaledY * Math.cos(radians);
+    } else if (degrees > 45 && degrees < 135) {
+      // Left
+      evData.xDiff = scaledY * Math.sin(radians);
+      evData.yDiff = scaledX * Math.sin(radians) * -1;
+    } else if (degrees > -135 && degrees < -45) {
+      // Right
+      evData.xDiff = scaledY * Math.sin(radians) * -1;
+      evData.yDiff = scaledX * Math.sin(radians);
+    }
 
     let nextCrop;
 
@@ -628,8 +661,52 @@ class ReactCrop extends PureComponent {
     return nextCrop;
   }
 
+  getRotatedCursor(handle, degrees) {
+    if ((degrees > -45 && degrees <= 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
+      // Top and Bottom
+      switch(handle) {
+        case "nw":
+          return {cursor: "nw-resize"};
+        case "n":
+          return {cursor: "n-resize"};
+        case "ne":
+          return {cursor: "ne-resize"};
+        case "e":
+          return {cursor: "e-resize"};
+        case "se":
+          return {cursor: "se-resize"};
+        case "s":
+          return {cursor: "s-resize"};
+        case "sw":
+          return {cursor: "sw-resize"};
+        case "w":
+          return {cursor: "w-resize"};
+      }
+    } else if ((degrees > -135 && degrees <= -45) || (degrees > 45 && degrees <= 135)) {
+      // Left and Right
+      switch(handle) {
+        case "nw":
+          return {cursor: "ne-resize"};
+        case "n":
+          return {cursor: "w-resize"};
+        case "ne":
+          return {cursor: "nw-resize"};
+        case "e":
+          return {cursor: "s-resize"};
+        case "se":
+          return {cursor: "sw-resize"};
+        case "s":
+          return {cursor: "e-resize"};
+        case "sw":
+          return {cursor: "se-resize"};
+        case "w":
+          return {cursor: "n-resize"};
+      }
+    }
+  }
+
   createCropSelection() {
-    const { disabled, locked, renderSelectionAddon, ruleOfThirds, crop } = this.props;
+    const { disabled, locked, renderSelectionAddon, ruleOfThirds, crop, rotate } = this.props;
     const style = this.getCropStyle();
 
     return (
@@ -640,22 +717,22 @@ class ReactCrop extends PureComponent {
         onPointerDown={this.onCropPointerDown}
       >
         {!disabled && !locked && (
-          <div className="ReactCrop__drag-elements">
-            <div className="ReactCrop__drag-bar ord-n" data-ord="n" />
-            <div className="ReactCrop__drag-bar ord-e" data-ord="e" />
-            <div className="ReactCrop__drag-bar ord-s" data-ord="s" />
-            <div className="ReactCrop__drag-bar ord-w" data-ord="w" />
+        <div className="ReactCrop__drag-elements">
+          <div className="ReactCrop__drag-bar ord-n" data-ord="n" />
+          <div className="ReactCrop__drag-bar ord-e" data-ord="e" />
+          <div className="ReactCrop__drag-bar ord-s" data-ord="s" />
+          <div className="ReactCrop__drag-bar ord-w" data-ord="w" />
 
-            <div className="ReactCrop__drag-handle ord-nw" data-ord="nw" />
-            <div className="ReactCrop__drag-handle ord-n" data-ord="n" />
-            <div className="ReactCrop__drag-handle ord-ne" data-ord="ne" />
-            <div className="ReactCrop__drag-handle ord-e" data-ord="e" />
-            <div className="ReactCrop__drag-handle ord-se" data-ord="se" />
-            <div className="ReactCrop__drag-handle ord-s" data-ord="s" />
-            <div className="ReactCrop__drag-handle ord-sw" data-ord="sw" />
-            <div className="ReactCrop__drag-handle ord-w" data-ord="w" />
-          </div>
-        )}
+          <div className="ReactCrop__drag-handle ord-nw" data-ord="nw" style={this.getRotatedCursor("nw", rotate)} />
+          <div className="ReactCrop__drag-handle ord-n" data-ord="n" style={this.getRotatedCursor("n", rotate)} />
+          <div className="ReactCrop__drag-handle ord-ne" data-ord="ne" style={this.getRotatedCursor("ne", rotate)} />
+          <div className="ReactCrop__drag-handle ord-e" data-ord="e" style={this.getRotatedCursor("e", rotate)} />
+          <div className="ReactCrop__drag-handle ord-se" data-ord="se" style={this.getRotatedCursor("se", rotate)} />
+          <div className="ReactCrop__drag-handle ord-s" data-ord="s" style={this.getRotatedCursor("s", rotate)} />
+          <div className="ReactCrop__drag-handle ord-sw" data-ord="sw" style={this.getRotatedCursor("sw", rotate)} />
+          <div className="ReactCrop__drag-handle ord-w" data-ord="w" style={this.getRotatedCursor("w", rotate)} />
+        </div>
+      )}
         {renderSelectionAddon && isCropValid(crop) && (
           <div className="ReactCrop__selection-addon" onMouseDown={e => e.stopPropagation()}>
             {renderSelectionAddon(this.state)}
@@ -833,7 +910,8 @@ ReactCrop.propTypes = {
   renderComponent: PropTypes.node,
   renderSelectionAddon: PropTypes.func,
   ruleOfThirds: PropTypes.bool,
-  scale: PropTypes.number
+  scale: PropTypes.number,
+  rotate: PropTypes.number
 };
 
 ReactCrop.defaultProps = {
@@ -860,7 +938,8 @@ ReactCrop.defaultProps = {
   imageStyle: undefined,
   renderSelectionAddon: undefined,
   ruleOfThirds: false,
-  scale: 1
+  scale: 1,
+  rotate: 0
 };
 
 export { ReactCrop as default, ReactCrop as Component, makeAspectCrop, containCrop };

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -265,7 +265,7 @@ class ReactCrop extends PureComponent {
   };
 
   onComponentPointerDown = e => {
-    const { crop, disabled, locked, keepSelection, onChange } = this.props;
+    const { crop, disabled, locked, keepSelection, onChange, scale } = this.props;
 
     const componentEl = this.mediaWrapperRef.firstChild;
 
@@ -286,8 +286,8 @@ class ReactCrop extends PureComponent {
     this.componentRef.focus({ preventScroll: true }); // All other browsers
 
     const rect = this.mediaWrapperRef.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
+    const x = (e.clientX - rect.left) / scale;
+    const y = (e.clientY - rect.top) / scale;
 
     const nextCrop = {
       unit: 'px',
@@ -325,7 +325,7 @@ class ReactCrop extends PureComponent {
   };
 
   onDocPointerMove = e => {
-    const { crop, disabled, onChange, onDragStart } = this.props;
+    const { crop, disabled, onChange, onDragStart, scale } = this.props;
 
     if (disabled) {
       return;
@@ -344,8 +344,8 @@ class ReactCrop extends PureComponent {
 
     const { evData } = this;
 
-    evData.xDiff = e.clientX - evData.clientStartX;
-    evData.yDiff = e.clientY - evData.clientStartY;
+    evData.xDiff = (e.clientX - evData.clientStartX) / scale;
+    evData.yDiff = (e.clientY - evData.clientStartY) / scale;
 
     let nextCrop;
 
@@ -833,6 +833,7 @@ ReactCrop.propTypes = {
   renderComponent: PropTypes.node,
   renderSelectionAddon: PropTypes.func,
   ruleOfThirds: PropTypes.bool,
+  scale: PropTypes.number
 };
 
 ReactCrop.defaultProps = {
@@ -859,6 +860,7 @@ ReactCrop.defaultProps = {
   imageStyle: undefined,
   renderSelectionAddon: undefined,
   ruleOfThirds: false,
+  scale: 1
 };
 
 export { ReactCrop as default, ReactCrop as Component, makeAspectCrop, containCrop };

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -293,15 +293,15 @@ class ReactCrop extends PureComponent {
     let scaledY = (e.clientY - rect.top) / scale;
     let degrees = rotate;
     let radians = Math.abs((degrees * Math.PI) / 180.0);
-    if ((degrees > -45 && degrees < 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
+    if ((degrees > -45 && degrees <= 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
       // Top and Bottom
       x = scaledX * Math.cos(radians);
       y = scaledY * Math.cos(radians);
-    } else if (degrees > 45 && degrees < 135) {
+    } else if (degrees > 45 && degrees <= 135) {
       // Left
       x = scaledY * Math.sin(radians);
       y = scaledX * Math.sin(radians) * -1;
-    } else if (degrees > -135 && degrees < -45) {
+    } else if (degrees > -135 && degrees <= -45) {
       // Right
       x = scaledY * Math.sin(radians) * -1;
       y = scaledX * Math.sin(radians);
@@ -366,15 +366,15 @@ class ReactCrop extends PureComponent {
     let scaledY = (e.clientY - evData.clientStartY) / scale;
     let degrees = rotate;
     let radians = Math.abs((degrees * Math.PI) / 180.0);
-    if ((degrees > -45 && degrees < 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
+    if ((degrees > -45 && degrees <= 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
       // Top and Bottom
       evData.xDiff = scaledX * Math.cos(radians);
       evData.yDiff = scaledY * Math.cos(radians);
-    } else if (degrees > 45 && degrees < 135) {
+    } else if (degrees > 45 && degrees <= 135) {
       // Left
       evData.xDiff = scaledY * Math.sin(radians);
       evData.yDiff = scaledX * Math.sin(radians) * -1;
-    } else if (degrees > -135 && degrees < -45) {
+    } else if (degrees > -135 && degrees <= -45) {
       // Right
       evData.xDiff = scaledY * Math.sin(radians) * -1;
       evData.yDiff = scaledX * Math.sin(radians);

--- a/lib/ReactCrop.js
+++ b/lib/ReactCrop.js
@@ -293,7 +293,7 @@ class ReactCrop extends PureComponent {
     let scaledY = (e.clientY - rect.top) / scale;
     let degrees = rotate;
     let radians = Math.abs((degrees * Math.PI) / 180.0);
-    if ((degrees > -45 && degrees < 45) || ((degrees >= -180 && degrees < -135) || (degrees > 135 && degrees <= 180))) {
+    if ((degrees > -45 && degrees < 45) || (Math.abs(degrees) > 135 && Math.abs(degrees) <= 180)) {
       // Top and Bottom
       x = scaledX * Math.cos(radians);
       y = scaledY * Math.cos(radians);


### PR DESCRIPTION
Hello. I am using this together with [react-zoom-pan-pinch](https://github.com/prc5/react-zoom-pan-pinch) in order to enable zooming + cropping. However, there is a problem where if the image is inside a parent div that is scaled, the cropping bounds will not follow the mouse cursor at all. I found an old PR that solves this exact same issue (#170), but I'm really not sure why it wasn't merged, maybe they just didn't do a good job explaining (since the name `delta` is confusing).

Current behavior when cropping a scaled image (doesn't follow the mouse at all):

![cropNoScale](https://user-images.githubusercontent.com/37512637/129461443-028b784c-f48a-4dac-821d-f9ebed9ed2a1.gif)

With the scale prop set:

![cropScale](https://user-images.githubusercontent.com/37512637/129461728-99e1e3e6-8d2c-4638-898c-6219e7e27a1e.gif)

I apologize for the laggy recording, but you can tell that it follows the mouse cursor a lot better.

Usage in code:

```js
<TransformWrapper onZoomStop={(ref) => setZoomScale(ref.state.scale)}>
    <TransformComponent>
        <div className="photo-container">
            <ReactCrop className="photo" src={image} scale={zoomScale} crop={cropState} 
              onChange={(crop, percentCrop) => setCropState(percentCrop)} 
              disabled={!cropEnabled} keepSelection={true}/>
        </div>
     </TransformComponent>
 </TransformWrapper>
```
