### PR TITLE
Miscellaneous fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A responsive image cropping tool for React",
   "repository": "https://github.com/DominicTobias/react-image-crop",
   "main": "dist/ReactCrop.min.js",
+  "types": "dist/index.d.ts",
   "style": "dist/ReactCrop.css",
   "files": [
     "dist",

--- a/src/ReactCrop.tsx
+++ b/src/ReactCrop.tsx
@@ -161,7 +161,7 @@ type YOrds = 'n' | 's';
 type XYOrds = 'nw' | 'ne' | 'se' | 'sw';
 type Ords = XOrds | YOrds | XYOrds;
 
-interface Crop {
+export interface Crop {
   aspect?: number;
   x: number;
   y: number;
@@ -194,7 +194,7 @@ export interface ReactCropProps {
   /** A string of classes to add to the main `ReactCrop` element. */
   className?: string;
   /** A React Node that will be inserted into the `ReactCrop` element */
-  children: React.ReactNode;
+  children?: React.ReactNode;
   /** Show the crop area as a circle. If your aspect is not 1 (a square) then the circle will be warped into an oval shape. Defaults to false. */
   circularCrop?: boolean;
   /** All crop params are initially optional. See README.md for more info. */
@@ -234,7 +234,7 @@ export interface ReactCropProps {
   /** Render a custom HTML element in place of an image. Useful if you want to support videos. */
   renderComponent?: React.ReactNode;
   /** Render a custom element in crop selection. */
-  renderSelectionAddon: (state: ReactCropState) => React.ReactNode;
+  renderSelectionAddon?: (state: ReactCropState) => React.ReactNode;
   /** Rotates the image, you should pass a value between -180 and 180. Defaults to 0. */
   rotate?: number;
   /** Show rule of thirds lines in the cropped area. Defaults to false. */
@@ -423,8 +423,8 @@ class ReactCrop extends PureComponent<ReactCropProps, ReactCropState> {
     (this.componentRef.current as HTMLDivElement).focus({ preventScroll: true }); // All other browsers
 
     const rect = (this.mediaWrapperRef.current as HTMLDivElement).getBoundingClientRect();
-    const x = e.clientX - rect.left / zoom;
-    const y = e.clientY - rect.top / zoom;
+    const x = (e.clientX - rect.left) / zoom;
+    const y = (e.clientY - rect.top) / zoom;
 
     const nextCrop: Crop = {
       unit: 'px',
@@ -486,8 +486,8 @@ class ReactCrop extends PureComponent<ReactCropProps, ReactCropState> {
 
     const { evData } = this;
 
-    evData.xDiff = e.clientX - evData.clientStartX / zoom;
-    evData.yDiff = e.clientY - evData.clientStartY / zoom;
+    evData.xDiff = (e.clientX - evData.clientStartX) / zoom;
+    evData.yDiff = (e.clientY - evData.clientStartY) / zoom;
 
     let nextCrop;
 
@@ -623,8 +623,13 @@ class ReactCrop extends PureComponent<ReactCropProps, ReactCropState> {
   };
 
   get mediaDimensions() {
-    const { clientWidth, clientHeight } = this.mediaWrapperRef.current as HTMLDivElement;
-    return { width: clientWidth, height: clientHeight };
+    let width = 0
+    let height = 0
+    if (this.mediaWrapperRef.current) {
+      width = this.mediaWrapperRef.current.clientWidth
+      height = this.mediaWrapperRef.current.clientHeight
+    }
+    return { width, height };
   }
 
   getCropStyle() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export { default } from './ReactCrop';
 export * from './ReactCrop';


### PR DESCRIPTION
Hi, the newest update was giving me a bunch of errors so I tried to fix them.

Fix: Export the default export in index.ts
```ts
export { default } from './ReactCrop';
```

Fix: Add types to package.json so Typescript finds them
```
"types": "dist/index.d.ts"
```

Fix: Refs are only available after the component renders, so `mediaDimensions()` needs to handle when the ref is `null`.
```ts
get mediaDimensions() {
    let width = 0
    let height = 0
    if (this.mediaWrapperRef.current) {
      width = this.mediaWrapperRef.current.clientWidth
      height = this.mediaWrapperRef.current.clientHeight
    }
    return { width, height };
  }
```

Fix: Zoom calculation was wrong because it was missing parentheses
```ts
// before
// const x = e.clientX - rect.left / zoom;
// const y = e.clientY - rect.top / zoom;
const x = (e.clientX - rect.left) / zoom;
const y = (e.clientY - rect.top) / zoom;
```

Fix: children and renderSelectionAddon should be optional
```ts
children?: React.ReactNode;
renderSelectionAddon?: (state: ReactCropState) => React.ReactNode;
```

Adjustment: Export the Crop interface, it may be useful to use in your own functions
```ts
export interface Crop
```