### PR TITLE
fix freeform resize left handle drift

### DIFF
--- a/src/ReactCrop.tsx
+++ b/src/ReactCrop.tsx
@@ -104,8 +104,8 @@ function containCrop(prevCrop: Partial<Crop>, crop: Partial<Crop>, imageWidth: n
   // Non-aspects are simple
   if (!pixelCrop.aspect) {
     if (pixelCrop.x < 0) {
-      pixelCrop.x = 0;
       pixelCrop.width += pixelCrop.x;
+      pixelCrop.x = 0;
     } else if (pixelCrop.x + pixelCrop.width > imageWidth) {
       pixelCrop.width = imageWidth - pixelCrop.x;
     }


### PR DESCRIPTION
We need to add (In this case subtract because it's negative) the x value to the width before it gets reset so the width won't change when it hits the boundaries.