### PR TITLE
Updated 'center aspect ratio crop' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Centering an aspect ratio crop is trickier especially when dealing with `%`. How
 
 ```js
 function onImageLoad(e) {
-  const { width, height } = e.currentTarget
+  const { naturalWidth: width, naturalHeight: height } = e.currentTarget;
 
   const crop = centerCrop(
     makeAspectCrop(


### PR DESCRIPTION
The image element size may be smaller than the original image size. That can lead to slightly incorrect values when using the crop area since the percentages are less precise. A better practice is to use naturalWidth and naturalHeight properties.