### PR TITLE
Fix usage with Preact

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "declaration": true,
     "allowJs": true,
-    "jsx": "react-jsx"
+    "jsx": "react"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
I'm using react-image-crop with Preact and webpack but I'm running into this error when rendering the component:

> TypeError: Cannot read properties of undefined (reading 'current')

After some digging, I found that it is coming from `react/jsx-runtime` which is being included in the minified react-image-crop bundle.

We could mark `react/jsx-runtime` as an external in the webpack config, but this may break when using it as a UMD bundle.

Instead, we can switch the JSX runtime mode to 'classic' by changing the tsconfig.

As an added bonus, the bundle is 0.4KB smaller (gzipped) this way.

tl;dr: change JSX runtime to classic to fix an error from bundling `react/jsx-runtime`