### PR TITLE
Fix the CDN link and add stylesheet CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ See the [sandbox demo](https://codesandbox.io/s/react-image-crop-demo-with-react
 ## CDN
 
 ```html
-<script src="https://unpkg.com/react-image-crop/dist/ReactCrop.min.js"></script>
+<link href="https://unpkg.com/react-image-crop/dist/ReactCrop.css" rel="stylesheet">
+<script src="https://unpkg.com/react-image-crop/dist/index.umd.cjs"></script>
 ```
 
 Note when importing the script globally using a `<script>` tag access the component with `ReactCrop.Component`.


### PR DESCRIPTION
This follows up the commit 2907c45caea81f69ca9a554ee9b7564c9ddc2d83.

After switching to Vite, the CDN link has been changed from `ReactCrop.min.js` to `index.umd.cjs`, so the README.md should indicate the new built file.

In addition, the stylesheet CDN link should also be included when using `index.umd.cjs`.