### PR TITLE
fix input in add-on components

### DIFF
--- a/src/ReactCrop.tsx
+++ b/src/ReactCrop.tsx
@@ -770,7 +770,7 @@ export class ReactCrop extends PureComponent<ReactCropProps, ReactCropState> {
           </div>
         )}
         {renderSelectionAddon && (
-          <div className="ReactCrop__selection-addon" onMouseDown={e => e.stopPropagation()}>
+          <div className="ReactCrop__selection-addon" onPointerDown={e => e.stopPropagation()}>
             {renderSelectionAddon(this.state)}
           </div>
         )}


### PR DESCRIPTION
In the demo example, we encountered an issue where we were unable to input any text into input elements rendered through `renderSelectionAddon`.

We found the [issue](https://github.com/DominicTobias/react-image-crop/issues/321), and it was successfully addressed in version 8.4.1. However, the problem persists in the latest version (v10.1.8).

We suspect that the root cause may be related to the change in the event handling, transitioning from onMouseDown to onPointerDown.

It now works after adding `stopPropagation` to the `onPointerDown` event.  
![image](https://github.com/DominicTobias/react-image-crop/assets/17408932/cf945391-2aa8-481b-b591-d2c38beab7a2)
